### PR TITLE
Add support for tagging tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add a test dependency for Cuppa in your project's POM:
 <dependency>
     <groupId>org.forgerock.cuppa</groupId>
     <artifactId>cuppa</artifactId>
-    <version>1.0.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -59,7 +59,7 @@ To get Surefire (the Maven plugin that runs unit tests) to run Cuppa tests, you'
             <dependency>
                 <groupId>org.forgerock.cuppa</groupId>
                 <artifactId>cuppa-surefire</artifactId>
-                <version>1.0.0</version>
+                <version>0.8.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </plugin>
@@ -75,7 +75,7 @@ Add a test dependency for Cuppa in your project's build file:
 
 ```groovy
 dependencies {
-    testCompile 'org.forgerock.cuppa:cuppa:1.0.0'
+    testCompile 'org.forgerock.cuppa:cuppa:0.8.0-SNAPSHOT'
 }
 ```
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -224,7 +224,7 @@
         <module name="ParameterAssignment"/>
         <module name="ParameterName"/>
         <module name="ParameterNumber">
-            <property name="max" value="8"/>
+            <property name="max" value="9"/>
         </module>
         <module name="ParenPad"/>
         <module name="RedundantImport"/>

--- a/cuppa/src/main/java/org/forgerock/cuppa/Cuppa.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Cuppa.java
@@ -20,6 +20,8 @@ import org.forgerock.cuppa.functions.HookFunction;
 import org.forgerock.cuppa.functions.TestBlockFunction;
 import org.forgerock.cuppa.functions.TestFunction;
 import org.forgerock.cuppa.internal.TestContainer;
+import org.forgerock.cuppa.model.TestBlockBuilder;
+import org.forgerock.cuppa.model.TestBuilder;
 
 /**
  * Use the methods of this class to define your tests.
@@ -40,6 +42,16 @@ public final class Cuppa {
     }
 
     /**
+     * Returns a builder for registering a described suite of tests to be run.
+     *
+     * @param description The description of the 'describe' block.
+     * @return The builder for registering a described suite of tests.
+     */
+    public static TestBlockBuilder describe(String description) {
+        return TestContainer.INSTANCE.describe(description);
+    }
+
+    /**
      * Registers a 'when' block to be run.
      *
      * @param description The description of the 'when' block.
@@ -47,6 +59,16 @@ public final class Cuppa {
      */
     public static void when(String description, TestBlockFunction function) {
         TestContainer.INSTANCE.when(description, function);
+    }
+
+    /**
+     * Returns a builder for registering a 'when' block to be run.
+     *
+     * @param description The description of the 'when' block.
+     * @return The builder for registering a 'when' block.
+     */
+    public static TestBlockBuilder when(String description) {
+        return TestContainer.INSTANCE.when(description);
     }
 
     /**
@@ -136,11 +158,14 @@ public final class Cuppa {
     }
 
     /**
-     * Registers a pending test function that has yet to be implemented.
+     * Returns a builder for registering a test function.
+     *
+     * <p>To register a pending test do not call the {@link TestBuilder#asserts(TestFunction)}.</p>
      *
      * @param description The description of the test function.
+     * @return The builder for registering a test function.
      */
-    public static void it(String description) {
-        TestContainer.INSTANCE.it(description);
+    public static TestBuilder it(String description) {
+        return TestContainer.INSTANCE.it(description);
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/CuppaTestProvider.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/CuppaTestProvider.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import org.forgerock.cuppa.internal.TestContainer;
+import org.forgerock.cuppa.model.Tags;
 import org.forgerock.cuppa.model.TestBlock;
 import org.forgerock.cuppa.reporters.Reporter;
 
@@ -37,7 +38,18 @@ public final class CuppaTestProvider {
      * @param reporter A reporter to apprise of test outcomes.
      */
     public static void runTests(Reporter reporter) {
-        TestContainer.INSTANCE.runTests(reporter);
+        runTests(reporter, Tags.EMPTY_TAGS);
+    }
+
+    /**
+     * Runs all the tests that have been loaded into the test framework that match the specified
+     * tags.
+     *
+     * @param reporter A reporter to apprise of test outcomes.
+     * @param tags Tags and anti-tags (excluded tags) to filter the tests to be run.
+     */
+    public static void runTests(Reporter reporter, Tags tags) {
+        TestContainer.INSTANCE.runTests(reporter, tags);
     }
 
     /**

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/InternalTestBlockBuilder.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/InternalTestBlockBuilder.java
@@ -17,8 +17,12 @@
 package org.forgerock.cuppa.internal;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.forgerock.cuppa.functions.HookFunction;
 import org.forgerock.cuppa.model.Behaviour;
@@ -26,7 +30,7 @@ import org.forgerock.cuppa.model.Hook;
 import org.forgerock.cuppa.model.Test;
 import org.forgerock.cuppa.model.TestBlock;
 
-final class TestBlockBuilder {
+final class InternalTestBlockBuilder {
 
     private final Behaviour behaviour;
     private final String description;
@@ -35,45 +39,53 @@ final class TestBlockBuilder {
     private final List<Hook> afterAfter = new ArrayList<>();
     private final List<Hook> beforeEachHooks = new ArrayList<>();
     private final List<Hook> afterEachHooks = new ArrayList<>();
-    private final List<Test> tests = new ArrayList<>();
+    private final List<TestBuilderImpl> testBuilders = new ArrayList<>();
+    private final Set<String> tags = new HashSet<>();
 
-    TestBlockBuilder(Behaviour behaviour, String description) {
+    InternalTestBlockBuilder(Behaviour behaviour, String description) {
         this.behaviour = behaviour;
         this.description = description;
     }
 
-    TestBlockBuilder addTestBlock(TestBlock testBlock) {
+    InternalTestBlockBuilder addTestBlock(TestBlock testBlock) {
         testBlocks.add(testBlock);
         return this;
     }
 
-    TestBlockBuilder addBefore(Optional<String> description, HookFunction function) {
+    InternalTestBlockBuilder addBefore(Optional<String> description, HookFunction function) {
         beforeHooks.add(new Hook(description, function));
         return this;
     }
 
-    TestBlockBuilder addAfter(Optional<String> description, HookFunction function) {
+    InternalTestBlockBuilder addAfter(Optional<String> description, HookFunction function) {
         afterAfter.add(new Hook(description, function));
         return this;
     }
 
-    TestBlockBuilder addBeforeEach(Optional<String> description, HookFunction function) {
+    InternalTestBlockBuilder addBeforeEach(Optional<String> description, HookFunction function) {
         beforeEachHooks.add(new Hook(description, function));
         return this;
     }
 
-    TestBlockBuilder addAfterEach(Optional<String> description, HookFunction function) {
+    InternalTestBlockBuilder addAfterEach(Optional<String> description, HookFunction function) {
         afterEachHooks.add(new Hook(description, function));
         return this;
     }
 
-    TestBlockBuilder addTest(Test test) {
-        tests.add(test);
+    InternalTestBlockBuilder addTest(TestBuilderImpl test) {
+        testBuilders.add(test);
+        return this;
+    }
+
+    InternalTestBlockBuilder eachWithTags(String tag, String... tags) {
+        this.tags.addAll(Arrays.asList(tags));
+        this.tags.add(tag);
         return this;
     }
 
     TestBlock build() {
+        List<Test> tests = testBuilders.stream().map(TestBuilderImpl::build).collect(Collectors.toList());
         return new TestBlock(behaviour, description, testBlocks, beforeHooks, afterAfter, beforeEachHooks,
-                afterEachHooks, tests);
+                afterEachHooks, tests, tags);
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBuilderImpl.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBuilderImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.forgerock.cuppa.functions.TestFunction;
+import org.forgerock.cuppa.model.Behaviour;
+import org.forgerock.cuppa.model.Test;
+import org.forgerock.cuppa.model.TestBuilder;
+
+final class TestBuilderImpl implements TestBuilder {
+
+    private final Behaviour behaviour;
+    private final String description;
+    private final Class<?> testClass;
+    private Optional<TestFunction> function = Optional.empty();
+    private Set<String> tags = new HashSet<>();
+
+    TestBuilderImpl(Behaviour behaviour, String description, Class<?> testClass) {
+        this.behaviour = behaviour;
+        this.description = description;
+        this.testClass = testClass;
+    }
+
+    @Override
+    public TestBuilder withTags(String tag, String... tags) {
+        this.tags.addAll(Arrays.asList(tags));
+        this.tags.add(tag);
+        return this;
+    }
+
+    @Override
+    public void asserts(TestFunction function) {
+        this.function = Optional.ofNullable(function);
+    }
+
+    Test build() {
+        return new Test(behaviour, testClass, description, function, tags);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Behaviour.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Behaviour.java
@@ -39,44 +39,50 @@ public enum Behaviour {
 
     /**
      * Registers a described suite of tests to be run.
+     *
      * <p>If {@link Behaviour#skip} then this test will be skipped.</p>
      *
      * @param description The description of the 'describe' block.
      * @param function The 'describe' block.
      */
     public void describe(String description, TestBlockFunction function) {
-        TestContainer.INSTANCE.describe(this, description, function);
+        TestContainer.INSTANCE.describe(this, description).then(function);
     }
 
     /**
      * Registers a 'when' block to be run.
+     *
      * <p>If {@link Behaviour#skip} then this test will be skipped.</p>
      *
      * @param description The description of the 'when' block.
      * @param function The 'when' block.
      */
     public void when(String description, TestBlockFunction function) {
-        TestContainer.INSTANCE.when(this, description, function);
+        TestContainer.INSTANCE.when(this, description).then(function);
     }
 
     /**
      * Registers a test function to be run.
+     *
      * <p>If {@link Behaviour#skip} then this test will be skipped.</p>
      *
      * @param description The description of the test function.
      * @param function The test function.
      */
     public void it(String description, TestFunction function) {
-        TestContainer.INSTANCE.it(this, description, function);
+        it(description).asserts(function);
     }
 
     /**
-     * Registers a pending test function that has yet to be implemented.
+     * Returns a builder for registering a test function.
+     *
+     * <p>To register a pending test do not call the {@link TestBuilder#asserts(TestFunction)}.</p>
      *
      * @param description The description of the test function.
+     * @return The builder for registering a test function.
      */
-    public void it(String description) {
-        TestContainer.INSTANCE.it(description);
+    public TestBuilder it(String description) {
+        return TestContainer.INSTANCE.it(this, description);
     }
 
     /**

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Tags.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Tags.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Encapsulates the tags to be used to filter which tests to be run as a part of the test run.
+ */
+public class Tags {
+
+    /**
+     * No tags specified, meaning no tests should be filtered from the test run.
+     */
+    public static final Tags EMPTY_TAGS = new Tags(Collections.emptySet(), Collections.emptySet());
+
+    /**
+     * The set of tags which tests must be tagged with to be included in the test run.
+     */
+    public final Set<String> tags;
+
+    /**
+     * The set of excluded tags which tests must not be tagged with to be included in the test run.
+     */
+    public final Set<String> excludedTags;
+
+    /**
+     * Constructs a {@code Tags} instance with the specified tags and anti-tags (excluded tags).
+     *
+     * @param tags The set of tags which tests must be tagged with to be included in the test run.
+     * @param excludedTags The set of excluded tags which tests must not be tagged with to be included
+     *     in the test run.
+     */
+    public Tags(Set<String> tags, Set<String> excludedTags) {
+        this.tags = tags;
+        this.excludedTags = excludedTags;
+    }
+
+    /**
+     * Constructs a {@code Tags} instance with the specified tags.
+     *
+     * @param tags The set of tags which tests must be tagged with to be included in the test run.
+     * @return The {@code Tags} instance.
+     */
+    public static Tags tags(Set<String> tags) {
+        return new Tags(tags, Collections.emptySet());
+    }
+
+    /**
+     * Constructs a {@code Tags} instance with the specified anti-tags (excluded tags).
+     *
+     * @param excludedTags The set of excluded tags which tests must not be tagged with to be
+     *     included in the test run.
+     * @return The {@code Tags} instance.
+     */
+    public static Tags excludedTags(Set<String> excludedTags) {
+        return new Tags(Collections.emptySet(), excludedTags);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Test.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Test.java
@@ -18,7 +18,9 @@ package org.forgerock.cuppa.model;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import org.forgerock.cuppa.functions.TestFunction;
 
 /**
@@ -47,6 +49,11 @@ public final class Test {
     public final Optional<TestFunction> function;
 
     /**
+     * The set of tags applied to the test.
+     */
+    public final Set<String> tags;
+
+    /**
      * Constructs a new test.
      *
      * @param behaviour The behaviour of the test.
@@ -54,8 +61,10 @@ public final class Test {
      * @param description The description of the test. Will be used for reporting.
      * @param function The body of the test. If the {@link Optional} is empty the test is
      *     classified as pending.
+     * @param tags The set of tags applied to the test.
      */
-    public Test(Behaviour behaviour, Class<?> testClass, String description, Optional<TestFunction> function) {
+    public Test(Behaviour behaviour, Class<?> testClass, String description, Optional<TestFunction> function,
+            Set<String> tags) {
         Objects.requireNonNull(behaviour, "Test must have a behaviour");
         Objects.requireNonNull(testClass, "Test must have a testClass");
         Objects.requireNonNull(description, "Test must have a description");
@@ -64,6 +73,7 @@ public final class Test {
         this.testClass = testClass;
         this.description = description;
         this.function = function;
+        this.tags = ImmutableSet.copyOf(tags);
     }
 
     @Override

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
@@ -20,8 +20,10 @@ import static org.forgerock.cuppa.model.Behaviour.only;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Encapsulates the 'describe' and 'when' function blocks and all nested 'describe', 'when' and
@@ -70,6 +72,11 @@ public final class TestBlock {
     public final ImmutableList<Test> tests;
 
     /**
+     * The set of tags applied to all tests within block.
+     */
+    public final Set<String> tags;
+
+    /**
      * Constructs a new TestBlock. Will convert mutable lists to immutable lists.
      *
      * @param behaviour Controls how the test block and its descendants behave.
@@ -80,9 +87,11 @@ public final class TestBlock {
      * @param beforeEachHooks Before each hooks. Will run before each test in this test block is executed.
      * @param afterEachHooks After each hooks. Will run after each test in this test block is executed.
      * @param tests Nested tests.
+     * @param tags The set of tags applied to all tests within block.
      */
     public TestBlock(Behaviour behaviour, String description, List<TestBlock> testBlocks, List<Hook> beforeHooks,
-            List<Hook> afterHook, List<Hook> beforeEachHooks, List<Hook> afterEachHooks, List<Test> tests) {
+            List<Hook> afterHook, List<Hook> beforeEachHooks, List<Hook> afterEachHooks, List<Test> tests,
+            Set<String> tags) {
         Objects.requireNonNull(behaviour, "TestBlock must have a behaviour");
         Objects.requireNonNull(description, "TestBlock must have a description");
         Objects.requireNonNull(testBlocks, "TestBlock must have testBlocks");
@@ -99,6 +108,7 @@ public final class TestBlock {
         this.beforeEachHooks = ImmutableList.copyOf(beforeEachHooks);
         this.afterEachHooks = ImmutableList.copyOf(afterEachHooks);
         this.tests = ImmutableList.copyOf(tests);
+        this.tags = ImmutableSet.copyOf(tags);
     }
 
     /**

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlockBuilder.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlockBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.model;
+
+import org.forgerock.cuppa.functions.TestBlockFunction;
+
+/**
+ * A builder for registering a test blocks.
+ */
+public interface TestBlockBuilder {
+
+    /**
+     * Specifies a set of tags to apply to all tests within block.
+     *
+     * @param tag The tag to apply.
+     * @param tags Subsequent tags to apply.
+     * @return This builder instance.
+     */
+    TestBlockBuilder eachWithTags(String tag, String... tags);
+
+    /**
+     * Registers a 'describe' or 'when' block to be run.
+     *
+     * @param function The 'describe' or 'when' block.
+     */
+    void then(TestBlockFunction function);
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/TestBuilder.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/TestBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.model;
+
+import org.forgerock.cuppa.functions.TestFunction;
+
+/**
+ * A builder for registering a test function.
+ *
+ * <p>To register a pending test do not call the {@link #asserts(TestFunction)}.</p>
+ */
+public interface TestBuilder {
+
+    /**
+     * Specifies a set of tags to apply to the test function.
+     *
+     * @param tag The tag to apply.
+     * @param tags Subsequent tags to apply.
+     * @return This builder instance.
+     */
+    TestBuilder withTags(String tag, String... tags);
+
+    /**
+     * The test function that will be run to assert behaviour.
+     *
+     * @param function The test function.
+     */
+    void asserts(TestFunction function);
+}

--- a/cuppa/src/test/java/org/forgerock/cuppa/TaggedTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/TaggedTests.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa;
+
+import static org.forgerock.cuppa.Cuppa.*;
+import static org.forgerock.cuppa.Cuppa.when;
+import static org.forgerock.cuppa.CuppaTestProvider.runTests;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.forgerock.cuppa.functions.TestFunction;
+import org.forgerock.cuppa.internal.TestContainer;
+import org.forgerock.cuppa.model.Tags;
+import org.forgerock.cuppa.reporters.Reporter;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TaggedTests {
+
+    @BeforeMethod
+    public void setup() {
+        TestContainer.INSTANCE.reset();
+        TestContainer.INSTANCE.setTestClass(HookTests.class);
+    }
+
+    @Test
+    public void shouldRunAllTestsWithNoRunTagsSpecified() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testFunction = mock(TestFunction.class);
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke")
+                        .asserts(testFunction);
+            });
+        }
+
+        //When
+        runTests(reporter);
+
+        //Then
+        verify(testFunction).apply();
+        verify(reporter).testPass(any());
+    }
+
+    @Test
+    public void shouldBeAbleToTagADescribeBlock() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        {
+            describe("tagged tests")
+                    .eachWithTags("smoke")
+                    .then(() -> {
+                        it("runs the tagged test", testFunction);
+                    });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testFunction).apply();
+        verify(reporter).testPass(any());
+    }
+
+    @Test
+    public void shouldOnlyRunMatchingTaggedTest() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testOneFunction = mock(TestFunction.class);
+        TestFunction testTwoFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke")
+                        .asserts(testOneFunction);
+                it("does not runs the non-matching tagged test")
+                        .withTags("long")
+                        .asserts(testTwoFunction);
+            });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testOneFunction).apply();
+        verify(testTwoFunction, never()).apply();
+        verify(reporter).testPass(any());
+    }
+
+    @Test
+    public void shouldOnlyRunMatchingTaggedTestAtWhenBlockLevel() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testOneFunction = mock(TestFunction.class);
+        TestFunction testTwoFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        {
+            describe("tagged tests", () -> {
+                when("the when is tagged 'smoke'")
+                        .eachWithTags("smoke")
+                        .then(() -> {
+                            it("runs the tagged test", testOneFunction);
+                        });
+                when("the when is tagged 'long'")
+                        .eachWithTags("long")
+                        .then(() -> {
+                            it("does not runs the non-matching tagged test", testTwoFunction);
+                        });
+            });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testOneFunction).apply();
+        verify(testTwoFunction, never()).apply();
+        verify(reporter).testPass(any());
+    }
+
+    @Test
+    public void shouldOnlyRunMatchingTaggedTestAtDescribeBlockLevel() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testOneFunction = mock(TestFunction.class);
+        TestFunction testTwoFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        {
+            describe("the describe is tagged 'smoke'")
+                    .eachWithTags("smoke")
+                    .then(() -> {
+                        it("runs the tagged test", testOneFunction);
+                    });
+            describe("the describe is tagged 'long'")
+                    .eachWithTags("long")
+                    .then(() -> {
+                        it("does not runs the non-matching tagged test", testTwoFunction);
+                    });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testOneFunction).apply();
+        verify(testTwoFunction, never()).apply();
+        verify(reporter).testPass(any());
+    }
+
+    @Test
+    public void shouldRunAllMatchingTaggedTests() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testOneFunction = mock(TestFunction.class);
+        TestFunction testTwoFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke")
+                        .asserts(testOneFunction);
+                it("runs the second tagged test")
+                        .withTags("smoke")
+                        .asserts(testTwoFunction);
+            });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testOneFunction).apply();
+        verify(testTwoFunction).apply();
+        verify(reporter, times(2)).testPass(any());
+    }
+
+    @Test
+    public void shouldRunAllMatchingTaggedTestsAtWhenBlockLevel() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testOneFunction = mock(TestFunction.class);
+        TestFunction testTwoFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        {
+            describe("tagged tests", () -> {
+                when("the when is tagged 'smoke'")
+                        .eachWithTags("smoke")
+                        .then(() -> {
+                            it("runs the tagged test", testOneFunction);
+                        });
+                when("the when is tagged 'smoke'")
+                        .eachWithTags("smoke")
+                        .then(() -> {
+                            it("runs the second tagged test", testTwoFunction);
+                        });
+            });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testOneFunction).apply();
+        verify(testTwoFunction).apply();
+        verify(reporter, times(2)).testPass(any());
+    }
+
+    @Test
+    public void shouldRunAllMatchingTaggedTestsAtDescribeBlockLevel() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testOneFunction = mock(TestFunction.class);
+        TestFunction testTwoFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        {
+            describe("the describe is tagged 'smoke'")
+                    .eachWithTags("smoke")
+                    .then(() -> {
+                        it("runs the tagged test", testOneFunction);
+                    });
+            describe("the describe is tagged 'smoke'")
+                    .eachWithTags("smoke")
+                    .then(() -> {
+                        it("runs the second tagged test", testTwoFunction);
+                    });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testOneFunction).apply();
+        verify(testTwoFunction).apply();
+        verify(reporter, times(2)).testPass(any());
+    }
+
+    @DataProvider
+    private Object[][] testTagsContainRunTag() {
+        return new Object[][]{
+            {"smoke"},
+            {"big"},
+            {"long"},
+        };
+    }
+
+    @Test(dataProvider = "testTagsContainRunTag")
+    public void shouldRunTestsWhichMatchAnyTag(String tag) throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testOneFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton(tag);
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke", "long", "big")
+                        .asserts(testOneFunction);
+            });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testOneFunction).apply();
+        verify(reporter).testPass(any());
+    }
+
+    @Test
+    public void shouldRunAllTestsWhichContainAnyRunTag() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testFunctionRun = mock(TestFunction.class);
+        TestFunction testFunctionNotRun = mock(TestFunction.class);
+        Set<String> tags = new HashSet<>(Arrays.asList("smoke", "big"));
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke", "long")
+                        .asserts(testFunctionRun);
+                it("runs the tagged test")
+                        .withTags("smoke", "big")
+                        .asserts(testFunctionRun);
+                it("runs the tagged test")
+                        .withTags("long", "big")
+                        .asserts(testFunctionRun);
+                it("runs the tagged test")
+                        .withTags("smoke")
+                        .asserts(testFunctionRun);
+                it("runs the tagged test")
+                        .withTags("long")
+                        .asserts(testFunctionNotRun);
+                it("runs the tagged test")
+                        .withTags("big")
+                        .asserts(testFunctionRun);
+                it("runs the tagged test")
+                        .withTags("long", "nightly")
+                        .asserts(testFunctionNotRun);
+            });
+        }
+
+        //When
+        runTests(reporter, Tags.tags(tags));
+
+        //Then
+        verify(testFunctionRun, times(5)).apply();
+        verify(testFunctionNotRun, never()).apply();
+    }
+
+    @Test
+    public void shouldNotRunTestsWhichMatchRunAntiTag() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testFunction = mock(TestFunction.class);
+        Set<String> excludedTags = Collections.singleton("smoke");
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke")
+                        .asserts(testFunction);
+            });
+        }
+
+        //When
+        runTests(reporter, Tags.excludedTags(excludedTags));
+
+        //Then
+        verify(testFunction, never()).apply();
+    }
+
+    @Test
+    public void shouldNotRunTestsWhichMatchBothRunTagAndAntiTag() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testFunction = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("smoke");
+        Set<String> excludedTags = Collections.singleton("smoke");
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke")
+                        .asserts(testFunction);
+            });
+        }
+
+        //When
+        runTests(reporter, new Tags(tags, excludedTags));
+
+        //Then
+        verify(testFunction, never()).apply();
+    }
+
+    @Test
+    public void shouldRunTestsWhichMatchRunTagAndNotAntiTag() throws Exception {
+
+        //Given
+        Reporter reporter = mock(Reporter.class);
+        TestFunction testFunctionNotRun = mock(TestFunction.class);
+        TestFunction testFunctionRun = mock(TestFunction.class);
+        Set<String> tags = Collections.singleton("long");
+        Set<String> excludedTags = Collections.singleton("smoke");
+        {
+            describe("tagged tests", () -> {
+                it("runs the tagged test")
+                        .withTags("smoke", "long")
+                        .asserts(testFunctionNotRun);
+                it("runs the tagged test")
+                        .withTags("long")
+                        .asserts(testFunctionRun);
+                it("runs the tagged test")
+                        .withTags("big")
+                        .asserts(testFunctionNotRun);
+            });
+        }
+
+        //When
+        runTests(reporter, new Tags(tags, excludedTags));
+
+        //Then
+        verify(testFunctionNotRun, never()).apply();
+        verify(testFunctionRun).apply();
+    }
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,5 +32,5 @@ kramdown:
   hard_wrap: false
 gems:
 - jekyll-paginate
-cuppa_version: 1.0.0
+cuppa_version: 0.8.0-SNAPSHOT
 github_url: https://github.com/cuppa-framework/cuppa

--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -6,6 +6,7 @@
   docs:
   - parameterised-tests
   - skipping-tests
+  - tagging-tests
   - exceptions
   - timeouts
   - reporters

--- a/docs/_docs/skipping-tests.md
+++ b/docs/_docs/skipping-tests.md
@@ -10,7 +10,7 @@ following syntax to mark the test as skipped.
 ```java
 skip.it("returns -1", () -> {
     // ...
-);
+});
 ```
 
 Skipped tests will be reported to remind you to restore the test before committing the code.
@@ -32,7 +32,7 @@ If you'd like to run a single test to debug a problem, just use the following sy
 ```java
 only.it("returns -1", () -> {
     // ...
-);
+});
 ```
 
 Likewise, this can be applied to `describe` and `when` blocks.

--- a/docs/_docs/tagging-tests.md
+++ b/docs/_docs/tagging-tests.md
@@ -1,0 +1,72 @@
+---
+title: Tagging Tests
+---
+
+{::options parse_block_html="true" /}
+
+<div class="alert alert-info" role="alert">
+#### Note
+
+Tagging tests only works with Maven Surefire/Failsafe integration at the moment.
+</div>
+
+## Tagging a Single Test
+
+Want to run just a sub-set of your tests? No problem. Simply tag your tests with one or more tags.
+ 
+```java
+it("returns -1")
+        .withTags("smoke")
+        .asserts(() -> {
+            // ...
+        });
+```
+
+Running the following command will only run the tests with the matching tag `smoke` and all the remaining tests will be 
+ignored.
+
+```bash
+mvn -Dtags=smoke test
+```
+
+Alternatively you can run all tests which __are not__ tagged with one or more specific tags.
+
+Running the following command will __not__ run the tests with the matching tag `slow` and all the remaining tests will 
+be run.
+
+```bash
+mvn -DexcludedTags=slow test
+```
+
+<div class="alert alert-info" role="alert">
+#### Note
+
+When running with a combination of TestNG or JUnit along side Cuppa, you can use the TestNG/JUnit way of 
+specifying/excluding groups so that you can run a sub-set of tests across both TestNG/JUnit and Cuppa.
+
+It's important to note that you cannot use both `-Dgroups=` and `-Dtags=` or `-DexcludedGroups=` and `-DexcludedTags=` 
+at the same time.
+</div>
+
+## Tagging Pending Tests
+
+Want to add a tag to a pending test? No worries. Simply omit the `.asserts` method call and your done!
+
+```java
+it("returns -1")
+        .withTags("smoke");
+```
+
+## Tagging a Set of Tests
+
+Similarly you can also tag all tests within a `describe` or `when` block:
+
+```java
+when("it is empty")
+        .eachWithTags("smoke")
+        .then(() -> {
+            it("returns -1", () -> {
+                // ...
+            });
+        });
+``` 


### PR DESCRIPTION
Adds support for tests to be tagged and integrates with surefire to handle groups specified via TestNG "groups/excludedGroups" if TestNG is on the classpath otherwise provides "tag/excludedTags" surefire property via the pom.xml or can be overridden using -Dtag=group on the command line.

No integration with JUnit as of yet as unsure on how JUnit deals with groups.