### PR TITLE
Add extension points via ConfigurationProvider

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -112,7 +112,7 @@
             <property name="sortImportsInGroupAlphabetically" value="true"/>
         </module>
         <module name="CyclomaticComplexity">
-            <property name="max" value="11"/>
+            <property name="max" value="12"/>
         </module>
         <module name="DeclarationOrder"/>
         <module name="DefaultComesLast"/>

--- a/cuppa-junit/src/main/java/org/forgerock/cuppa/junit/ReportJUnitAdapter.java
+++ b/cuppa-junit/src/main/java/org/forgerock/cuppa/junit/ReportJUnitAdapter.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.cuppa.junit;
 
-import org.forgerock.cuppa.CuppaTestProvider;
+import org.forgerock.cuppa.ReporterSupport;
 import org.forgerock.cuppa.model.Hook;
 import org.forgerock.cuppa.model.Test;
 import org.forgerock.cuppa.model.TestBlock;
@@ -63,7 +63,7 @@ final class ReportJUnitAdapter implements Reporter {
 
     @Override
     public void hookError(Hook hook, Throwable cause) {
-        CuppaTestProvider.filterStackTrace(cause);
+        ReporterSupport.filterStackTrace(cause);
         notifier.fireTestFailure(new Failure(getDescription(hook.description.orElse("Hook")), cause));
     }
 
@@ -87,13 +87,13 @@ final class ReportJUnitAdapter implements Reporter {
 
     @Override
     public void testFail(Test test, AssertionError e) {
-        CuppaTestProvider.filterStackTrace(e);
+        ReporterSupport.filterStackTrace(e);
         notifier.fireTestFailure(new Failure(getDescription(test.description), e));
     }
 
     @Override
     public void testError(Test test, Throwable e) {
-        CuppaTestProvider.filterStackTrace(e);
+        ReporterSupport.filterStackTrace(e);
         notifier.fireTestFailure(new Failure(getDescription(test.description), e));
     }
 

--- a/cuppa-junit/src/test/java/org/forgerock/cuppa/junit/CuppaRunnerTest.java
+++ b/cuppa-junit/src/test/java/org/forgerock/cuppa/junit/CuppaRunnerTest.java
@@ -183,7 +183,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class PassingTest {
+    public static class PassingTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -194,7 +194,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class FailingTest {
+    public static class FailingTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -207,7 +207,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class ErroringTest {
+    public static class ErroringTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -220,7 +220,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class PendingTest {
+    public static class PendingTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -231,7 +231,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class SkippedTest {
+    public static class SkippedTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -242,7 +242,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class FailingBeforeHookTest {
+    public static class FailingBeforeHookTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -256,7 +256,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class FailingAfterHookTest {
+    public static class FailingAfterHookTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -270,7 +270,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class FailingBeforeEachHookTest {
+    public static class FailingBeforeEachHookTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {
@@ -284,7 +284,7 @@ public class CuppaRunnerTest {
     }
 
     @RunWith(CuppaRunner.class)
-    static class FailingAfterEachHookTest {
+    public static class FailingAfterEachHookTest {
         {
             describe("Cuppa", () -> {
                 when("running with CuppaRunner", () -> {

--- a/cuppa-surefire/src/main/java/org/forgerock/cuppa/maven/surefire/CuppaSurefireReporter.java
+++ b/cuppa-surefire/src/main/java/org/forgerock/cuppa/maven/surefire/CuppaSurefireReporter.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.forgerock.cuppa.maven.surefire;
 
 import org.apache.maven.surefire.report.PojoStackTraceWriter;
 import org.apache.maven.surefire.report.RunListener;
 import org.apache.maven.surefire.report.SimpleReportEntry;
-import org.forgerock.cuppa.CuppaTestProvider;
+import org.forgerock.cuppa.ReporterSupport;
 import org.forgerock.cuppa.model.Hook;
 import org.forgerock.cuppa.model.TestBlock;
 import org.forgerock.cuppa.reporters.Reporter;
@@ -62,14 +78,14 @@ final class CuppaSurefireReporter implements Reporter {
 
     @Override
     public void testFail(org.forgerock.cuppa.model.Test test, AssertionError cause) {
-        CuppaTestProvider.filterStackTrace(cause);
+        ReporterSupport.filterStackTrace(cause);
         listener.testFailed(new SimpleReportEntry(test.testClass.getCanonicalName(), test.description,
                 new PojoStackTraceWriter(test.testClass.getCanonicalName(), test.description, cause), 0));
     }
 
     @Override
     public void testError(org.forgerock.cuppa.model.Test test, Throwable cause) {
-        CuppaTestProvider.filterStackTrace(cause);
+        ReporterSupport.filterStackTrace(cause);
         listener.testError(new SimpleReportEntry(test.testClass.getCanonicalName(), test.description,
                 new PojoStackTraceWriter(test.testClass.getCanonicalName(), test.description, cause), 0));
     }

--- a/cuppa/src/main/java/org/forgerock/cuppa/Configuration.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Configuration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.forgerock.cuppa.model.TestBlock;
+
+/**
+ * Holds configuration settings for Cuppa.
+ */
+public final class Configuration {
+    List<Function<TestBlock, TestBlock>> testTransforms = new ArrayList<>();
+    TestInstantiator testInstantiator = Class::newInstance;
+
+    Configuration() {
+    }
+
+    /**
+     * Sets the class that will be used to instantiate test classes. Use this function if your test classes require
+     * additional steps to instantiate, such as automatic dependency injection.
+     *
+     * @param testInstantiator A class that instantiates test classes.
+     */
+    public void setTestInstantiator(TestInstantiator testInstantiator) {
+        Objects.requireNonNull(testInstantiator, "Test instantiator must not be null");
+        this.testInstantiator = testInstantiator;
+    }
+
+    /**
+     * Register a transform. This will be called with the root test block after instantiating all test classes on the
+     * classpath. Use this function to manipulate the tests and their hooks before they are executed.
+     *
+     * @param transform The transform. Must not be null. Must not return null.
+     */
+    public void registerTestTreeTransform(Function<TestBlock, TestBlock> transform) {
+        Objects.requireNonNull(transform, "Transform must not be null");
+        testTransforms.add(transform);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/ConfigurationProvider.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/ConfigurationProvider.java
@@ -14,29 +14,16 @@
  * limitations under the License.
  */
 
-package org.forgerock.cuppa.internal;
-
-import org.forgerock.cuppa.model.TestBlock;
+package org.forgerock.cuppa;
 
 /**
- * Internal exception used to handle hooks throwing exceptions.
+ * Provides configuration for Cuppa at runtime.
  */
-public final class HookException extends RuntimeException {
-
-    private final TestBlock testBlock;
-
+public interface ConfigurationProvider {
     /**
-     * Creates a new hook exception.
+     * Should configure Cuppa using the provided {@link Configuration}.
      *
-     * @param testBlock The test block that the hook is in.
-     * @param cause The exception that the hook function threw.
+     * @param configuration The configuration that will be provided by Cuppa.
      */
-    public HookException(TestBlock testBlock, Throwable cause) {
-        super(cause);
-        this.testBlock = testBlock;
-    }
-
-    public TestBlock getTestBlock() {
-        return testBlock;
-    }
+    void configure(Configuration configuration);
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/ReporterSupport.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/ReporterSupport.java
@@ -19,46 +19,12 @@ package org.forgerock.cuppa;
 import java.util.Arrays;
 import java.util.Optional;
 
-import org.forgerock.cuppa.internal.TestContainer;
-import org.forgerock.cuppa.model.Tags;
-import org.forgerock.cuppa.model.TestBlock;
-import org.forgerock.cuppa.reporters.Reporter;
-
 /**
- * This class allows integrations to control Cuppa and provides access to its model.
+ * Provides utility methods for reporters.
  */
-public final class CuppaTestProvider {
+public final class ReporterSupport {
 
-    private CuppaTestProvider() {
-    }
-
-    /**
-     * Runs all the tests that have been loaded into the test framework.
-     *
-     * @param reporter A reporter to apprise of test outcomes.
-     */
-    public static void runTests(Reporter reporter) {
-        runTests(reporter, Tags.EMPTY_TAGS);
-    }
-
-    /**
-     * Runs all the tests that have been loaded into the test framework that match the specified
-     * tags.
-     *
-     * @param reporter A reporter to apprise of test outcomes.
-     * @param tags Tags and anti-tags (excluded tags) to filter the tests to be run.
-     */
-    public static void runTests(Reporter reporter, Tags tags) {
-        TestContainer.INSTANCE.runTests(reporter, tags);
-    }
-
-    /**
-     * Returns the test block that contains all user-defined tests and test blocks.
-     *
-     * @return The root test block.
-     */
-    public static TestBlock getRootTestBlock() {
-        return TestContainer.INSTANCE.getRootTestBlock();
+    private ReporterSupport() {
     }
 
     /**
@@ -108,14 +74,5 @@ public final class CuppaTestProvider {
 
     private static boolean isStackTraceElementForLambda(StackTraceElement element) {
         return element.getMethodName().startsWith("lambda$");
-    }
-
-    /**
-     * Sets the class from which tests are being loaded.
-     *
-     * @param testClass The test class.
-     */
-    public static void setTestClass(Class testClass) {
-        TestContainer.INSTANCE.setTestClass(testClass);
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa;
+
+import static org.forgerock.cuppa.model.Behaviour.skip;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.forgerock.cuppa.functions.TestFunction;
+import org.forgerock.cuppa.internal.EmptyTestBlockFilter;
+import org.forgerock.cuppa.internal.HookException;
+import org.forgerock.cuppa.internal.OnlyTestBlockFilter;
+import org.forgerock.cuppa.internal.TagTestBlockFilter;
+import org.forgerock.cuppa.internal.TestContainer;
+import org.forgerock.cuppa.model.Behaviour;
+import org.forgerock.cuppa.model.Hook;
+import org.forgerock.cuppa.model.Tags;
+import org.forgerock.cuppa.model.TestBlock;
+import org.forgerock.cuppa.reporters.Reporter;
+
+/**
+ * Runs Cuppa tests.
+ */
+public final class Runner {
+    private static final ServiceLoader<ConfigurationProvider> CONFIGURATION_PROVIDER_LOADER
+            = ServiceLoader.load(ConfigurationProvider.class);
+
+    private final ImmutableList<Function<TestBlock, TestBlock>> coreTestTransforms;
+    private final Configuration configuration;
+
+    /**
+     * Creates a new runner.
+     */
+    public Runner() {
+        this(Tags.EMPTY_TAGS);
+    }
+
+    /**
+     * Creates a new runner with the given run tags.
+     *
+     * @param runTags Tags to filter the tests on.
+     */
+    public Runner(Tags runTags) {
+        configuration = getConfiguration();
+        coreTestTransforms =
+                ImmutableList.of(new OnlyTestBlockFilter(), new TagTestBlockFilter(runTags),
+                        new EmptyTestBlockFilter());
+    }
+
+    /**
+     * Runs the tests in the provided test classes, using the provided reporter.
+     *
+     * @param rootBlock The root test block that contains all tests to be run.
+     * @param reporter The reporter to use to report test results.
+     */
+    public void run(TestBlock rootBlock, Reporter reporter) {
+        run(rootBlock, reporter, configuration);
+    }
+
+    @VisibleForTesting
+    void run(TestBlock rootBlock, Reporter reporter, Configuration configuration) {
+        TestContainer.INSTANCE.setRunningTests(true);
+        reporter.start();
+        TestBlock transformedRootBlock = transformTests(rootBlock, configuration.testTransforms);
+        runTests(transformedRootBlock, transformedRootBlock.behaviour, reporter, TestFunction::apply);
+        reporter.end();
+    }
+
+    /**
+     * Instantiates the test classes, which define tests as side effects, and return the root test block.
+     *
+     * @param testClasses The test classes that contain the tests to be executed.
+     * @return The root block that contains all other test blocks and their tests.
+     */
+    public TestBlock defineTests(Iterable<Class<?>> testClasses) {
+        return defineTests(testClasses, configuration.testInstantiator);
+    }
+
+    private TestBlock defineTests(Iterable<Class<?>> testClasses, TestInstantiator testInstantiator) {
+        for (Class<?> testClass : testClasses) {
+            try {
+                TestContainer.INSTANCE.setTestClass(testClass);
+                testInstantiator.instantiate(testClass);
+            } catch (Exception e) {
+                throw new IllegalStateException("Must be able to instantiate test class", e);
+            }
+        }
+        return TestContainer.INSTANCE.getRootTestBlock();
+    }
+
+    private Configuration getConfiguration() {
+        Configuration configuration = new Configuration();
+        Iterator<ConfigurationProvider> iterator = CONFIGURATION_PROVIDER_LOADER.iterator();
+        if (iterator.hasNext()) {
+            ConfigurationProvider configurationProvider = iterator.next();
+            if (iterator.hasNext()) {
+                throw new IllegalStateException("There must only be a single configuration provider available on the"
+                        + "classpath");
+            }
+            configurationProvider.configure(configuration);
+        }
+        return configuration;
+    }
+
+    private TestBlock transformTests(TestBlock rootBlock, List<Function<TestBlock, TestBlock>> transforms) {
+        return StreamSupport.stream(Iterables.concat(transforms, coreTestTransforms).spliterator(), false)
+                .reduce(Function.identity(), Function::andThen)
+                .apply(rootBlock);
+    }
+
+    private void runTests(TestBlock testBlock, Behaviour behaviour, Reporter reporter, TestWrapper outerTestWrapper) {
+        Behaviour combinedBehaviour = behaviour.combine(testBlock.behaviour);
+        TestWrapper testWrapper = createWrapper(testBlock, outerTestWrapper, reporter);
+        try {
+            reporter.describeStart(testBlock);
+            for (Hook hook : testBlock.beforeHooks) {
+                try {
+                    hook.function.apply();
+                } catch (Exception e) {
+                    reporter.hookError(hook, e);
+                    return;
+                }
+            }
+            for (org.forgerock.cuppa.model.Test t : testBlock.tests) {
+                testWrapper.apply(() -> runTest(t, combinedBehaviour, reporter));
+            }
+            testBlock.testBlocks.stream()
+                    .forEach((d) -> runTests(d, combinedBehaviour, reporter, testWrapper));
+        } catch (HookException e) {
+            if (e.getTestBlock() != testBlock) {
+                throw e;
+            }
+        } catch (Exception e) {
+            // This should never happen if the test framework is correct because
+            // all exceptions from user code should've been caught by now.
+            throw new RuntimeException(e);
+        } finally {
+            runAfterHooks(testBlock, reporter);
+            reporter.describeEnd(testBlock);
+        }
+    }
+
+    private void runTest(org.forgerock.cuppa.model.Test test, Behaviour behaviour, Reporter reporter) {
+        if (!test.function.isPresent()) {
+            reporter.testPending(test);
+        } else if (behaviour.combine(test.behaviour) != skip) {
+            try {
+                reporter.testStart(test);
+                test.function.get().apply();
+                reporter.testPass(test);
+            } catch (AssertionError e) {
+                reporter.testFail(test, e);
+            } catch (Exception e) {
+                reporter.testError(test, e);
+            } finally {
+                reporter.testEnd(test);
+            }
+        } else {
+            reporter.testSkip(test);
+        }
+    }
+
+    private TestWrapper createWrapper(TestBlock testBlock, TestWrapper outerTestRunner, Reporter reporter) {
+        return outerTestRunner.compose((f) -> {
+            try {
+                for (Hook hook : testBlock.beforeEachHooks) {
+                    try {
+                        hook.function.apply();
+                    } catch (Exception e) {
+                        reporter.hookError(hook, e);
+                        throw new HookException(testBlock, e);
+                    }
+                }
+                f.apply();
+            } finally {
+                for (Hook hook : testBlock.afterEachHooks) {
+                    try {
+                        hook.function.apply();
+                    } catch (Exception e) {
+                        reporter.hookError(hook, e);
+                        throw new HookException(testBlock, e);
+                    }
+                }
+            }
+        });
+    }
+
+    private void runAfterHooks(TestBlock testBlock, Reporter reporter) {
+        for (Hook hook : testBlock.afterHooks) {
+            try {
+                hook.function.apply();
+            } catch (Exception e) {
+                reporter.hookError(hook, e);
+                return;
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface TestWrapper {
+        void apply(TestFunction testRunner) throws Exception;
+
+        default TestWrapper compose(TestWrapper after) {
+            return (f) -> apply(() -> after.apply(f));
+        }
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/TestInstantiator.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/TestInstantiator.java
@@ -14,29 +14,18 @@
  * limitations under the License.
  */
 
-package org.forgerock.cuppa.internal;
-
-import org.forgerock.cuppa.model.TestBlock;
+package org.forgerock.cuppa;
 
 /**
- * Internal exception used to handle hooks throwing exceptions.
+ * Instantiates test classes.
  */
-public final class HookException extends RuntimeException {
-
-    private final TestBlock testBlock;
-
+@FunctionalInterface
+public interface TestInstantiator {
     /**
-     * Creates a new hook exception.
+     * Instantiate a test class. Must throw an exception if it was not possible to instantiate the test class.
      *
-     * @param testBlock The test block that the hook is in.
-     * @param cause The exception that the hook function threw.
+     * @param testClass The class to instantiate.
+     * @throws Exception Thrown if test class could not be instantiated.
      */
-    public HookException(TestBlock testBlock, Throwable cause) {
-        super(cause);
-        this.testBlock = testBlock;
-    }
-
-    public TestBlock getTestBlock() {
-        return testBlock;
-    }
+    void instantiate(Class<?> testClass) throws Exception;
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/EmptyTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/EmptyTestBlockFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.internal;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.forgerock.cuppa.model.TestBlock;
+
+/**
+ * Filter out test blocks that do not contain any tests.
+ */
+public final class EmptyTestBlockFilter implements Function<TestBlock, TestBlock> {
+    @Override
+    public TestBlock apply(TestBlock testBlock) {
+        List<TestBlock> testBlocks = testBlock.testBlocks.stream()
+                .map(this::apply)
+                .filter(b -> !isEmpty(b))
+                .collect(Collectors.toList());
+        return new TestBlock(testBlock.behaviour, testBlock.description, testBlocks, testBlock.beforeHooks,
+                testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, testBlock.tests,
+                testBlock.tags);
+    }
+
+    private boolean isEmpty(TestBlock testBlock) {
+        return testBlock.testBlocks.isEmpty() && testBlock.tests.isEmpty();
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/OnlyTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/OnlyTestBlockFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.internal;
+
+import static org.forgerock.cuppa.model.Behaviour.only;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.forgerock.cuppa.model.TestBlock;
+
+/**
+ * Filters out all tests that are not marked as "only" if any test is marked as "only". Otherwise, does nothing.
+ */
+public final class OnlyTestBlockFilter implements Function<TestBlock, TestBlock> {
+    @Override
+    public TestBlock apply(TestBlock rootBlock) {
+        boolean hasOnlyTests = hasOnlyTests(rootBlock);
+        if (!hasOnlyTests) {
+            return rootBlock;
+        }
+        return pruneNotOnlyTests(rootBlock);
+    }
+
+    private TestBlock pruneNotOnlyTests(TestBlock testBlock) {
+        if (testBlock.behaviour == only) {
+            return testBlock;
+        }
+        List<TestBlock> testBlocks = testBlock.testBlocks.stream()
+                .map(this::pruneNotOnlyTests)
+                .collect(Collectors.toList());
+        List<org.forgerock.cuppa.model.Test> tests = testBlock.tests.stream()
+                .filter(t -> t.behaviour == only)
+                .collect(Collectors.toList());
+        return new TestBlock(testBlock.behaviour, testBlock.description, testBlocks, testBlock.beforeHooks,
+                testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests, testBlock.tags);
+    }
+
+    private boolean hasOnlyTests(TestBlock block) {
+        return block.behaviour == only
+                || block.tests.stream().anyMatch(t -> t.behaviour == only)
+                || block.testBlocks.stream().anyMatch(this::hasOnlyTests);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TagTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TagTestBlockFilter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.internal;
+
+import static com.google.common.collect.Sets.intersection;
+import static com.google.common.collect.Sets.union;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.forgerock.cuppa.model.Tags;
+import org.forgerock.cuppa.model.Test;
+import org.forgerock.cuppa.model.TestBlock;
+
+/**
+ * Filters the test tree to only include tests that have tags that match the given run tags, excluding any tests that
+ * have the given excluded run tags.
+ */
+public final class TagTestBlockFilter implements Function<TestBlock, TestBlock> {
+    private final Tags runTags;
+
+    /**
+     * Creates a new filter.
+     *
+     * @param runTags The tags to include/exclude.
+     */
+    public TagTestBlockFilter(Tags runTags) {
+        this.runTags = runTags;
+    }
+
+    @Override
+    public TestBlock apply(TestBlock testBlock) {
+        if (runTags.tags.isEmpty() && runTags.excludedTags.isEmpty()) {
+            return testBlock;
+        }
+        return filterTests(testBlock, Collections.emptySet());
+    }
+
+    private TestBlock filterTests(TestBlock testBlock, Set<String> parentBlockTags) {
+        Set<String> blockTags = union(testBlock.tags, parentBlockTags);
+        List<TestBlock> testBlocks = testBlock.testBlocks.stream()
+                .map(b -> filterTests(b, blockTags))
+                .collect(Collectors.toList());
+        List<Test> tests = testBlock.tests.stream()
+                .filter(t -> shouldRun(union(t.tags, blockTags)))
+                .collect(Collectors.toList());
+        return new TestBlock(testBlock.behaviour, testBlock.description, testBlocks, testBlock.beforeHooks,
+                testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests, testBlock.tags);
+    }
+
+    private boolean shouldInclude(Set<String> testTags) {
+        return !intersection(testTags, runTags.tags).isEmpty();
+    }
+
+    private boolean shouldExclude(Set<String> testTags) {
+        return !intersection(testTags, runTags.excludedTags).isEmpty();
+    }
+
+    private boolean shouldRun(Set<String> testTags) {
+        return shouldInclude(testTags) && !shouldExclude(testTags);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
@@ -28,11 +28,9 @@ import org.forgerock.cuppa.functions.HookFunction;
 import org.forgerock.cuppa.functions.TestBlockFunction;
 import org.forgerock.cuppa.functions.TestFunction;
 import org.forgerock.cuppa.model.Behaviour;
-import org.forgerock.cuppa.model.Tags;
 import org.forgerock.cuppa.model.TestBlock;
 import org.forgerock.cuppa.model.TestBlockBuilder;
 import org.forgerock.cuppa.model.TestBuilder;
-import org.forgerock.cuppa.reporters.Reporter;
 
 /**
  * Singleton container for user-defined tests.
@@ -248,27 +246,14 @@ public enum TestContainer {
      *
      * @param testClass The test class.
      */
-    @SuppressFBWarnings(value = "ME_ENUM_FIELD_SETTER",
-            justification = "Need to be able to set the class in which the tests are defined when they are registered.")
+    @SuppressFBWarnings(value = "ME_ENUM_FIELD_SETTER", justification = "Enum is being (ab)used for a singleton.")
     public void setTestClass(Class<?> testClass) {
         this.testClass = testClass;
     }
 
-    /**
-     * Runs all the tests that have been loaded into the test framework.
-     *
-     * @param reporter A reporter to apprise of test outcomes.
-     * @param tags The set of tags to filter the tests to run by.
-     */
-    public void runTests(Reporter reporter, Tags tags) {
-        if (stack.size() != 1) {
-            throw new IllegalStateException("runTests cannot be run from within a 'describe' or 'when'");
-        }
-        runningTests = true;
-        TestBlock rootBlock = rootBuilder.build();
-        reporter.start();
-        new TestRunner().runTests(rootBlock, rootBlock.hasOnlyTests(), reporter, tags);
-        reporter.end();
+    @SuppressFBWarnings(value = "ME_ENUM_FIELD_SETTER", justification = "Enum is being (ab)used for a singleton.")
+    public void setRunningTests(boolean runningTests) {
+        this.runningTests = runningTests;
     }
 
     /**

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestRunner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestRunner.java
@@ -136,7 +136,7 @@ final class TestRunner {
     }
 
     private void runAfterHooks(TestBlock testBlock, Reporter reporter) {
-        for (Hook hook : testBlock.afterHook) {
+        for (Hook hook : testBlock.afterHooks) {
             try {
                 hook.function.apply();
             } catch (Exception e) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
@@ -16,8 +16,6 @@
 
 package org.forgerock.cuppa.model;
 
-import static org.forgerock.cuppa.model.Behaviour.only;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -54,7 +52,7 @@ public final class TestBlock {
     /**
      * After hooks. Will be run once after all tests in this test block are executed.
      */
-    public final ImmutableList<Hook> afterHook;
+    public final ImmutableList<Hook> afterHooks;
 
     /**
      * Before each hooks. Will run before each test in this test block is executed.
@@ -83,20 +81,20 @@ public final class TestBlock {
      * @param description The description of the test block. Will be used for reporting.
      * @param testBlocks Nested test blocks.
      * @param beforeHooks Before hooks. Will be run once before any tests in this test block are executed.
-     * @param afterHook After hooks. Will be run once after all tests in this test block are executed.
+     * @param afterHooks After hooks. Will be run once after all tests in this test block are executed.
      * @param beforeEachHooks Before each hooks. Will run before each test in this test block is executed.
      * @param afterEachHooks After each hooks. Will run after each test in this test block is executed.
      * @param tests Nested tests.
      * @param tags The set of tags applied to all tests within block.
      */
     public TestBlock(Behaviour behaviour, String description, List<TestBlock> testBlocks, List<Hook> beforeHooks,
-            List<Hook> afterHook, List<Hook> beforeEachHooks, List<Hook> afterEachHooks, List<Test> tests,
+            List<Hook> afterHooks, List<Hook> beforeEachHooks, List<Hook> afterEachHooks, List<Test> tests,
             Set<String> tags) {
         Objects.requireNonNull(behaviour, "TestBlock must have a behaviour");
         Objects.requireNonNull(description, "TestBlock must have a description");
         Objects.requireNonNull(testBlocks, "TestBlock must have testBlocks");
         Objects.requireNonNull(beforeHooks, "TestBlock must have beforeHooks");
-        Objects.requireNonNull(afterHook, "TestBlock must have afterHook");
+        Objects.requireNonNull(afterHooks, "TestBlock must have afterHook");
         Objects.requireNonNull(beforeEachHooks, "TestBlock must have beforeEachHooks");
         Objects.requireNonNull(afterEachHooks, "TestBlock must have afterEachHooks");
         Objects.requireNonNull(tests, "TestBlock must have tests");
@@ -104,22 +102,11 @@ public final class TestBlock {
         this.description = description;
         this.testBlocks = ImmutableList.copyOf(testBlocks);
         this.beforeHooks = ImmutableList.copyOf(beforeHooks);
-        this.afterHook = ImmutableList.copyOf(afterHook);
+        this.afterHooks = ImmutableList.copyOf(afterHooks);
         this.beforeEachHooks = ImmutableList.copyOf(beforeEachHooks);
         this.afterEachHooks = ImmutableList.copyOf(afterEachHooks);
         this.tests = ImmutableList.copyOf(tests);
         this.tags = ImmutableSet.copyOf(tags);
-    }
-
-    /**
-     * Determine if this test block contains any tests or test blocks marked as {@link Behaviour#only}.
-     *
-     * @return {@code true} if this block, or any block or test under it, is marked as {@link Behaviour#only}.
-     */
-    public boolean hasOnlyTests() {
-        return behaviour == only
-                || tests.stream().anyMatch(t -> t.behaviour == only)
-                || testBlocks.stream().anyMatch(TestBlock::hasOnlyTests);
     }
 
     @Override
@@ -137,16 +124,17 @@ public final class TestBlock {
             && Objects.equals(description, testBlock.description)
             && Objects.equals(testBlocks, testBlock.testBlocks)
             && Objects.equals(beforeHooks, testBlock.beforeHooks)
-            && Objects.equals(afterHook, testBlock.afterHook)
+            && Objects.equals(afterHooks, testBlock.afterHooks)
             && Objects.equals(beforeEachHooks, testBlock.beforeEachHooks)
             && Objects.equals(afterEachHooks, testBlock.afterEachHooks)
-            && Objects.equals(tests, testBlock.tests);
+            && Objects.equals(tests, testBlock.tests)
+            && Objects.equals(tags, testBlock.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(behaviour, description, testBlocks, beforeHooks, afterHook, beforeEachHooks, afterEachHooks,
-                tests);
+        return Objects.hash(behaviour, description, testBlocks, beforeHooks, afterHooks, beforeEachHooks,
+                afterEachHooks, tests, tags);
     }
 
     @Override
@@ -156,10 +144,11 @@ public final class TestBlock {
             + ", description='" + description + '\''
             + ", testBlocks=" + testBlocks
             + ", beforeHooks=" + beforeHooks
-            + ", afterHook=" + afterHook
+            + ", afterHooks=" + afterHooks
             + ", beforeEachHooks=" + beforeEachHooks
             + ", afterEachHooks=" + afterEachHooks
             + ", tests=" + tests
+            + ", tags=" + tags
             + '}';
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/reporters/DefaultReporter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/reporters/DefaultReporter.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.forgerock.cuppa.CuppaTestProvider;
+import org.forgerock.cuppa.ReporterSupport;
 import org.forgerock.cuppa.model.Hook;
 import org.forgerock.cuppa.model.Test;
 import org.forgerock.cuppa.model.TestBlock;
@@ -97,7 +97,7 @@ public final class DefaultReporter implements Reporter {
                 TestFailure failure = failures.get(i);
                 stream.println("  " + (i + 1) + ")" + failure.description + ":");
                 stream.print("     ");
-                CuppaTestProvider.filterStackTrace(failure.cause);
+                ReporterSupport.filterStackTrace(failure.cause);
                 failure.cause.printStackTrace(stream);
             }
         }

--- a/cuppa/src/test/java/org/forgerock/cuppa/AbstractTest.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/AbstractTest.java
@@ -1,0 +1,22 @@
+package org.forgerock.cuppa;
+
+import org.forgerock.cuppa.internal.TestContainer;
+import org.forgerock.cuppa.model.Tags;
+import org.forgerock.cuppa.reporters.Reporter;
+import org.testng.annotations.BeforeMethod;
+
+public class AbstractTest {
+    @BeforeMethod
+    public void setup() {
+        TestContainer.INSTANCE.reset();
+        TestContainer.INSTANCE.setTestClass(this.getClass());
+    }
+
+    public void runTests(Reporter reporter) {
+        runTests(reporter, Tags.EMPTY_TAGS);
+    }
+
+    public void runTests(Reporter reporter, Tags tags) {
+        new Runner(tags).run(TestContainer.INSTANCE.getRootTestBlock(), reporter, new Configuration());
+    }
+}

--- a/cuppa/src/test/java/org/forgerock/cuppa/BasicApiTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/BasicApiTests.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.forgerock.cuppa.Cuppa.*;
 import static org.forgerock.cuppa.Cuppa.when;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.forgerock.cuppa.ModelFinder.findTest;
 import static org.mockito.Mockito.*;
 
@@ -29,19 +28,10 @@ import java.util.stream.Stream;
 
 import org.forgerock.cuppa.functions.TestBlockFunction;
 import org.forgerock.cuppa.functions.TestFunction;
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.reporters.Reporter;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class BasicApiTests {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(BasicApiTests.class);
-    }
-
+public class BasicApiTests extends AbstractTest {
     @Test
     public void basicApiUsageWithSingleTestBlock() throws Exception {
 

--- a/cuppa/src/test/java/org/forgerock/cuppa/DynamicDataTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/DynamicDataTests.java
@@ -19,7 +19,6 @@ package org.forgerock.cuppa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.cuppa.Cuppa.describe;
 import static org.forgerock.cuppa.Cuppa.it;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.forgerock.cuppa.ModelFinder.findTest;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -28,19 +27,10 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.reporters.Reporter;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class DynamicDataTests {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(DynamicDataTests.class);
-    }
-
+public class DynamicDataTests extends AbstractTest {
     @Test
     public void canCreateTestsDynamically() {
 

--- a/cuppa/src/test/java/org/forgerock/cuppa/HookExceptionTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/HookExceptionTests.java
@@ -18,7 +18,6 @@ package org.forgerock.cuppa;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.forgerock.cuppa.Cuppa.*;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.forgerock.cuppa.ModelFinder.findHook;
 import static org.forgerock.cuppa.ModelFinder.findTest;
 import static org.mockito.Mockito.*;
@@ -31,13 +30,11 @@ import java.util.function.BiConsumer;
 import org.forgerock.cuppa.functions.HookFunction;
 import org.forgerock.cuppa.functions.TestBlockFunction;
 import org.forgerock.cuppa.functions.TestFunction;
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.reporters.Reporter;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class HookExceptionTests {
+public class HookExceptionTests extends AbstractTest {
 
     private static final List<BiConsumer<String, HookFunction>> ALL_HOOKS =
             new ArrayList<BiConsumer<String, HookFunction>>() {
@@ -48,12 +45,6 @@ public class HookExceptionTests {
             add(Cuppa::afterEach);
         }
     };
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(HookExceptionTests.class);
-    }
 
     @Test
     public void shouldReturnSingleErrorResultIfBeforeHookThrowsException() throws Exception {

--- a/cuppa/src/test/java/org/forgerock/cuppa/HookTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/HookTests.java
@@ -17,28 +17,17 @@
 package org.forgerock.cuppa;
 
 import static org.forgerock.cuppa.Cuppa.*;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 
 import org.forgerock.cuppa.functions.HookFunction;
 import org.forgerock.cuppa.functions.TestFunction;
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.reporters.Reporter;
 import org.mockito.InOrder;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-
-public class HookTests {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(HookTests.class);
-    }
-
+public class HookTests extends AbstractTest {
     @Test
     public void beforeShouldRunOnceBeforeTests() throws Exception {
 

--- a/cuppa/src/test/java/org/forgerock/cuppa/ModelFinder.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/ModelFinder.java
@@ -17,12 +17,12 @@
 package org.forgerock.cuppa;
 
 import static java.util.stream.Stream.concat;
-import static org.forgerock.cuppa.CuppaTestProvider.getRootTestBlock;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.model.Hook;
 import org.forgerock.cuppa.model.Test;
 import org.forgerock.cuppa.model.TestBlock;
@@ -43,7 +43,10 @@ public final class ModelFinder {
      * @throws NoSuchElementException If no test was found with the given description.
      */
     public static Test findTest(String description) {
-        return getTests(getRootTestBlock()).filter(t -> t.description.equals(description)).findFirst().get();
+        return getTests(TestContainer.INSTANCE.getRootTestBlock())
+                .filter(t -> t.description.equals(description))
+                .findFirst()
+                .get();
     }
 
     private static Stream<Test> getTests(TestBlock block) {
@@ -58,7 +61,10 @@ public final class ModelFinder {
      * @throws NoSuchElementException If no test block was found with the given description.
      */
     public static TestBlock findTestBlock(String description) {
-        return getTestBlocks(getRootTestBlock()).filter(b -> b.description.equals(description)).findFirst().get();
+        return getTestBlocks(TestContainer.INSTANCE.getRootTestBlock())
+                .filter(b -> b.description.equals(description))
+                .findFirst()
+                .get();
     }
 
     private static Stream<TestBlock> getTestBlocks(TestBlock block) {
@@ -76,7 +82,7 @@ public final class ModelFinder {
      * @throws NoSuchElementException If no hook was found with the given description.
      */
     public static Hook findHook(String description) {
-        return getHooks(getRootTestBlock())
+        return getHooks(TestContainer.INSTANCE.getRootTestBlock())
                 .filter(h -> h.description.equals(Optional.of(description)))
                 .findFirst()
                 .get();
@@ -84,7 +90,7 @@ public final class ModelFinder {
 
     private static Stream<Hook> getHooks(TestBlock block) {
         Stream<Hook> hooks = concat(block.beforeHooks.stream(),
-                concat(block.afterHook.stream(),
+                concat(block.afterHooks.stream(),
                 concat(block.beforeEachHooks.stream(),
                 block.afterEachHooks.stream())));
         Stream<Hook> nestedHooks = block.testBlocks.stream().flatMap(ModelFinder::getHooks);

--- a/cuppa/src/test/java/org/forgerock/cuppa/PendingTestTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/PendingTestTests.java
@@ -19,23 +19,13 @@ package org.forgerock.cuppa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.cuppa.Cuppa.*;
 import static org.forgerock.cuppa.Cuppa.when;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.forgerock.cuppa.ModelFinder.findTest;
 import static org.mockito.Mockito.*;
 
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.reporters.Reporter;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class PendingTestTests {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(PendingTestTests.class);
-    }
-
+public class PendingTestTests extends AbstractTest {
     @Test
     public void supportPendingTest() {
 

--- a/cuppa/src/test/java/org/forgerock/cuppa/ReportingTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/ReportingTests.java
@@ -18,25 +18,15 @@ package org.forgerock.cuppa;
 
 import static org.forgerock.cuppa.Cuppa.*;
 import static org.forgerock.cuppa.Cuppa.when;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.forgerock.cuppa.ModelFinder.findTest;
 import static org.forgerock.cuppa.ModelFinder.findTestBlock;
 import static org.mockito.Mockito.*;
 
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.reporters.Reporter;
 import org.mockito.InOrder;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class ReportingTests {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(ReportingTests.class);
-    }
-
+public class ReportingTests extends AbstractTest {
     @Test
     public void reporterShouldBeNotifiedAtTheStart() {
 

--- a/cuppa/src/test/java/org/forgerock/cuppa/SkipTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/SkipTests.java
@@ -18,25 +18,16 @@ package org.forgerock.cuppa;
 
 import static org.forgerock.cuppa.Cuppa.*;
 import static org.forgerock.cuppa.Cuppa.when;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.forgerock.cuppa.ModelFinder.findTest;
-import static org.forgerock.cuppa.model.Behaviour.*;
+import static org.forgerock.cuppa.model.Behaviour.only;
+import static org.forgerock.cuppa.model.Behaviour.skip;
 import static org.mockito.Mockito.*;
 
 import org.forgerock.cuppa.functions.TestFunction;
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.reporters.Reporter;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class SkipTests {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(SkipTests.class);
-    }
-
+public class SkipTests extends AbstractTest {
     @Test
     public void shouldSkipTestIfTestIsMarkedSkip() throws Exception {
 

--- a/cuppa/src/test/java/org/forgerock/cuppa/TaggedTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/TaggedTests.java
@@ -18,7 +18,6 @@ package org.forgerock.cuppa;
 
 import static org.forgerock.cuppa.Cuppa.*;
 import static org.forgerock.cuppa.Cuppa.when;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -28,21 +27,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.forgerock.cuppa.functions.TestFunction;
-import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.model.Tags;
 import org.forgerock.cuppa.reporters.Reporter;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class TaggedTests {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(HookTests.class);
-    }
-
+public class TaggedTests extends AbstractTest {
     @Test
     public void shouldRunAllTestsWithNoRunTagsSpecified() throws Exception {
 
@@ -343,7 +333,7 @@ public class TaggedTests {
     }
 
     @Test
-    public void shouldNotRunTestsWhichMatchRunAntiTag() throws Exception {
+    public void shouldNotRunTestsWhichMatchExcludedTags() throws Exception {
 
         //Given
         Reporter reporter = mock(Reporter.class);
@@ -365,7 +355,7 @@ public class TaggedTests {
     }
 
     @Test
-    public void shouldNotRunTestsWhichMatchBothRunTagAndAntiTag() throws Exception {
+    public void shouldNotRunTestsWhichMatchBothRunTagsAndExcludedTags() throws Exception {
 
         //Given
         Reporter reporter = mock(Reporter.class);

--- a/cuppa/src/test/java/org/forgerock/cuppa/reporters/DefaultReporterTest.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/reporters/DefaultReporterTest.java
@@ -19,24 +19,15 @@ package org.forgerock.cuppa.reporters;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.cuppa.Cuppa.*;
-import static org.forgerock.cuppa.CuppaTestProvider.runTests;
 import static org.forgerock.cuppa.model.Behaviour.skip;
 
 import java.io.ByteArrayOutputStream;
 
+import org.forgerock.cuppa.AbstractTest;
 import org.forgerock.cuppa.functions.TestFunction;
-import org.forgerock.cuppa.internal.TestContainer;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class DefaultReporterTest {
-
-    @BeforeMethod
-    public void setup() {
-        TestContainer.INSTANCE.reset();
-        TestContainer.INSTANCE.setTestClass(DefaultReporterTest.class);
-    }
-
+public class DefaultReporterTest extends AbstractTest {
     @Test
     public void reporterShouldLookGreatForPassingTests() {
 
@@ -103,7 +94,6 @@ public class DefaultReporterTest {
                 "  1 failing",
                 "",
                 "  1) describe when failing test:",
-                "     java.lang.AssertionError:",
         };
         String expectedOutput = String.join(System.lineSeparator(), expectedLines);
         assertThat(output).startsWith(expectedOutput);
@@ -237,8 +227,6 @@ public class DefaultReporterTest {
         String[] expectedLines = {
                 "",
                 "",
-                "  describe",
-                "    when",
                 "",
                 "",
                 "  0 passing",
@@ -291,7 +279,6 @@ public class DefaultReporterTest {
                 "  2 pending",
                 "",
                 "  1) describe when failing test:",
-                "     java.lang.AssertionError:",
         };
         String expectedOutput = String.join(System.lineSeparator(), expectedLines);
         assertThat(output).startsWith(expectedOutput);

--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -11,6 +11,7 @@
   - timeouts
   - reporters
   - integrating-with-existing-tests
+  - using-guice
   - writing-a-reporter
 - title: Javadoc
   docs:

--- a/docs/_docs/integration-api.md
+++ b/docs/_docs/integration-api.md
@@ -1,4 +1,0 @@
----
-title: Integration API
----
-

--- a/docs/_docs/using-guice.md
+++ b/docs/_docs/using-guice.md
@@ -1,0 +1,35 @@
+---
+title: Using Guice with Cuppa
+---
+
+Cuppa provides a hook to allow you to customise how your test classes are instantiated.
+This keeps Cuppa agnostic about which inversion of control container you happen to be using.
+
+To do this, you need to write a class that implements `ConfigurationProvider` and sets the class instantiator:
+
+```java
+package com.example;
+
+import com.google.inject.Guice;
+import org.forgerock.cuppa.ConfigurationProvider;
+
+public final class MyConfigurationProvider implements ConfigurationProvider {
+    @Override
+    public void configure(Configuration configuration) {
+        // Setup Guice as needed...
+        Injector injector = Guice.createInjector(new MyModule());
+        configuration.setClassInstantiator(injector::getInstance);
+    }
+}
+```
+
+Cuppa uses a [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) to find the
+configuration provider.
+Hence, you need to provide a configuration file called `META-INF/services/org.forgerock.cuppa.ConfigurationProvider`
+that contains the fully-qualified class name of your class:
+
+```
+com.example.MyConfigurationProvider
+```
+
+Ensure that this file is on the classpath when running Cuppa.


### PR DESCRIPTION
This change adds the ability to extend Cuppa in two ways:

* Control how test classes are instantiated. This is useful if you want to use dependency injection in your tests.
* Manipulate the tree of tests before the tests are run. This is a very flexible mechanism that could be used to do lot's of different things. Tags could be implemented purely as an extension using this mechanism.

This is achieved by adding the `ConfigurationProvider` interface, which users may implement and make available to the [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html).

I've reimplemented the tags and "only" features as tree transforms. 