### PR TITLE
Ensure JUnit descriptions are unique

### DIFF
--- a/cuppa-junit/src/main/java/org/forgerock/cuppa/junit/CuppaRunner.java
+++ b/cuppa-junit/src/main/java/org/forgerock/cuppa/junit/CuppaRunner.java
@@ -47,15 +47,18 @@ public final class CuppaRunner extends Runner {
 
     @Override
     public Description getDescription() {
-        Description description = createSuiteDescription(testClass);
-        rootBlock.testBlocks.forEach(b -> description.addChild(getDescriptionOfDescribeBlock(b)));
+        Description description = createSuiteDescription(testClass.getName(), rootBlock.description);
+        rootBlock.testBlocks.forEach(b ->
+                description.addChild(getDescriptionOfDescribeBlock(b, rootBlock.description)));
         return description;
     }
 
-    private Description getDescriptionOfDescribeBlock(TestBlock testBlock) {
-        Description description = createSuiteDescription(testBlock.description);
-        testBlock.testBlocks.forEach(b -> description.addChild(getDescriptionOfDescribeBlock(b)));
-        testBlock.tests.forEach(b -> description.addChild(createTestDescription(testClass, b.description)));
+    private Description getDescriptionOfDescribeBlock(TestBlock testBlock, String parentDescription) {
+        String blockDescription = parentDescription + testBlock.description;
+        Description description = createSuiteDescription(testBlock.description, blockDescription);
+        testBlock.testBlocks.forEach(b -> description.addChild(getDescriptionOfDescribeBlock(b, blockDescription)));
+        testBlock.tests.forEach(test -> description.addChild(createTestDescription(testClass.getName(),
+                test.description, blockDescription + test.description)));
         return description;
     }
 


### PR DESCRIPTION
The JUnit `Description` class provides an overloaded constructor that allows you to specify a unique id. I've used the full string description of the block/test. Would be nice to just be able to pass the `TestBlock`/`Test` itself, but unfortunately right now they do not use their parents to compare themselves, so it wouldn't fix the problem.

Fixes #60.