### PR TITLE
Improve reporting for hook errors

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -111,7 +111,7 @@
             <property name="sortImportsInGroupAlphabetically" value="true"/>
         </module>
         <module name="CyclomaticComplexity">
-            <property name="max" value="12"/>
+            <property name="max" value="13"/>
         </module>
         <module name="DeclarationOrder"/>
         <module name="DefaultComesLast"/>
@@ -223,7 +223,7 @@
         <module name="ParameterAssignment"/>
         <module name="ParameterName"/>
         <module name="ParameterNumber">
-            <property name="max" value="9"/>
+            <property name="max" value="10"/>
         </module>
         <module name="ParenPad"/>
         <module name="RedundantImport"/>

--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -16,6 +16,8 @@
 
 package org.forgerock.cuppa;
 
+import static org.forgerock.cuppa.model.HookType.*;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -138,7 +140,7 @@ public final class Runner {
         TestWrapper testWrapper = createWrapper(testBlock, outerTestWrapper, reporter);
         try {
             reporter.describeStart(testBlock);
-            for (Hook hook : testBlock.beforeHooks) {
+            for (Hook hook : testBlock.hooksOfType(BEFORE)) {
                 try {
                     hook.function.apply();
                 } catch (Exception e) {
@@ -188,7 +190,7 @@ public final class Runner {
     private TestWrapper createWrapper(TestBlock testBlock, TestWrapper outerTestRunner, Reporter reporter) {
         return outerTestRunner.compose((f) -> {
             try {
-                for (Hook hook : testBlock.beforeEachHooks) {
+                for (Hook hook : testBlock.hooksOfType(BEFORE_EACH)) {
                     try {
                         hook.function.apply();
                     } catch (Exception e) {
@@ -198,7 +200,7 @@ public final class Runner {
                 }
                 f.apply();
             } finally {
-                for (Hook hook : testBlock.afterEachHooks) {
+                for (Hook hook : testBlock.hooksOfType(AFTER_EACH)) {
                     try {
                         hook.function.apply();
                     } catch (Exception e) {
@@ -211,7 +213,7 @@ public final class Runner {
     }
 
     private void runAfterHooks(TestBlock testBlock, Reporter reporter) {
-        for (Hook hook : testBlock.afterHooks) {
+        for (Hook hook : testBlock.hooksOfType(AFTER)) {
             try {
                 hook.function.apply();
             } catch (Exception e) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/EmptyTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/EmptyTestBlockFilter.java
@@ -33,8 +33,7 @@ public final class EmptyTestBlockFilter implements Function<TestBlock, TestBlock
                 .filter(b -> !isEmpty(b))
                 .collect(Collectors.toList());
         return new TestBlock(testBlock.behaviour, testBlock.testClass, testBlock.description, testBlocks,
-                testBlock.beforeHooks, testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks,
-                testBlock.tests, testBlock.options);
+                testBlock.hooks, testBlock.tests, testBlock.options);
     }
 
     private boolean isEmpty(TestBlock testBlock) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/EmptyTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/EmptyTestBlockFilter.java
@@ -32,9 +32,9 @@ public final class EmptyTestBlockFilter implements Function<TestBlock, TestBlock
                 .map(this::apply)
                 .filter(b -> !isEmpty(b))
                 .collect(Collectors.toList());
-        return new TestBlock(testBlock.behaviour, testBlock.description, testBlocks, testBlock.beforeHooks,
-                testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, testBlock.tests,
-                testBlock.options);
+        return new TestBlock(testBlock.behaviour, testBlock.testClass, testBlock.description, testBlocks,
+                testBlock.beforeHooks, testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks,
+                testBlock.tests, testBlock.options);
     }
 
     private boolean isEmpty(TestBlock testBlock) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/OnlyTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/OnlyTestBlockFilter.java
@@ -47,8 +47,9 @@ public final class OnlyTestBlockFilter implements Function<TestBlock, TestBlock>
         List<org.forgerock.cuppa.model.Test> tests = testBlock.tests.stream()
                 .filter(t -> t.behaviour == ONLY)
                 .collect(Collectors.toList());
-        return new TestBlock(testBlock.behaviour, testBlock.description, testBlocks, testBlock.beforeHooks,
-                testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests, testBlock.options);
+        return new TestBlock(testBlock.behaviour, testBlock.testClass, testBlock.description, testBlocks,
+                testBlock.beforeHooks, testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests,
+                testBlock.options);
     }
 
     private boolean hasOnlyTests(TestBlock block) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/OnlyTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/OnlyTestBlockFilter.java
@@ -48,8 +48,7 @@ public final class OnlyTestBlockFilter implements Function<TestBlock, TestBlock>
                 .filter(t -> t.behaviour == ONLY)
                 .collect(Collectors.toList());
         return new TestBlock(testBlock.behaviour, testBlock.testClass, testBlock.description, testBlocks,
-                testBlock.beforeHooks, testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests,
-                testBlock.options);
+                testBlock.hooks, tests, testBlock.options);
     }
 
     private boolean hasOnlyTests(TestBlock block) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TagTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TagTestBlockFilter.java
@@ -64,8 +64,7 @@ public final class TagTestBlockFilter implements Function<TestBlock, TestBlock> 
                 .filter(t -> shouldRun(union(getTags(t.options), blockTags)))
                 .collect(Collectors.toList());
         return new TestBlock(testBlock.behaviour, testBlock.testClass, testBlock.description, testBlocks,
-                testBlock.beforeHooks, testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests,
-                testBlock.options);
+                testBlock.hooks, tests, testBlock.options);
     }
 
     private boolean shouldInclude(Set<String> testTags) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TagTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TagTestBlockFilter.java
@@ -63,8 +63,9 @@ public final class TagTestBlockFilter implements Function<TestBlock, TestBlock> 
         List<Test> tests = testBlock.tests.stream()
                 .filter(t -> shouldRun(union(getTags(t.options), blockTags)))
                 .collect(Collectors.toList());
-        return new TestBlock(testBlock.behaviour, testBlock.description, testBlocks, testBlock.beforeHooks,
-                testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests, testBlock.options);
+        return new TestBlock(testBlock.behaviour, testBlock.testClass, testBlock.description, testBlocks,
+                testBlock.beforeHooks, testBlock.afterHooks, testBlock.beforeEachHooks, testBlock.afterEachHooks, tests,
+                testBlock.options);
     }
 
     private boolean shouldInclude(Set<String> testTags) {

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBlockBuilder.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBlockBuilder.java
@@ -36,10 +36,7 @@ final class TestBlockBuilder {
     private final String description;
     private final Options options;
     private final List<TestBlock> testBlocks = new ArrayList<>();
-    private final List<Hook> beforeHooks = new ArrayList<>();
-    private final List<Hook> afterAfter = new ArrayList<>();
-    private final List<Hook> beforeEachHooks = new ArrayList<>();
-    private final List<Hook> afterEachHooks = new ArrayList<>();
+    private final List<Hook> hooks = new ArrayList<>();
     private final List<Test> tests = new ArrayList<>();
 
     TestBlockBuilder(Behaviour behaviour, Class<?> testClass, String description, Options options) {
@@ -55,22 +52,22 @@ final class TestBlockBuilder {
     }
 
     TestBlockBuilder addBefore(Optional<String> description, HookFunction function) {
-        beforeHooks.add(new Hook(BEFORE, description, function));
+        hooks.add(new Hook(BEFORE, description, function));
         return this;
     }
 
     TestBlockBuilder addAfter(Optional<String> description, HookFunction function) {
-        afterAfter.add(new Hook(AFTER, description, function));
+        hooks.add(new Hook(AFTER, description, function));
         return this;
     }
 
     TestBlockBuilder addBeforeEach(Optional<String> description, HookFunction function) {
-        beforeEachHooks.add(new Hook(BEFORE_EACH, description, function));
+        hooks.add(new Hook(BEFORE_EACH, description, function));
         return this;
     }
 
     TestBlockBuilder addAfterEach(Optional<String> description, HookFunction function) {
-        afterEachHooks.add(new Hook(AFTER_EACH, description, function));
+        hooks.add(new Hook(AFTER_EACH, description, function));
         return this;
     }
 
@@ -80,7 +77,6 @@ final class TestBlockBuilder {
     }
 
     TestBlock build() {
-        return new TestBlock(behaviour, testClass, description, testBlocks, beforeHooks, afterAfter, beforeEachHooks,
-                afterEachHooks, tests, options);
+        return new TestBlock(behaviour, testClass, description, testBlocks, hooks, tests, options);
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBlockBuilder.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBlockBuilder.java
@@ -16,6 +16,8 @@
 
 package org.forgerock.cuppa.internal;
 
+import static org.forgerock.cuppa.model.HookType.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +32,7 @@ import org.forgerock.cuppa.model.TestBlock;
 final class TestBlockBuilder {
 
     private final Behaviour behaviour;
+    private final Class<?> testClass;
     private final String description;
     private final Options options;
     private final List<TestBlock> testBlocks = new ArrayList<>();
@@ -39,8 +42,9 @@ final class TestBlockBuilder {
     private final List<Hook> afterEachHooks = new ArrayList<>();
     private final List<Test> tests = new ArrayList<>();
 
-    TestBlockBuilder(Behaviour behaviour, String description, Options options) {
+    TestBlockBuilder(Behaviour behaviour, Class<?> testClass, String description, Options options) {
         this.behaviour = behaviour;
+        this.testClass = testClass;
         this.description = description;
         this.options = options;
     }
@@ -51,22 +55,22 @@ final class TestBlockBuilder {
     }
 
     TestBlockBuilder addBefore(Optional<String> description, HookFunction function) {
-        beforeHooks.add(new Hook(description, function));
+        beforeHooks.add(new Hook(BEFORE, description, function));
         return this;
     }
 
     TestBlockBuilder addAfter(Optional<String> description, HookFunction function) {
-        afterAfter.add(new Hook(description, function));
+        afterAfter.add(new Hook(AFTER, description, function));
         return this;
     }
 
     TestBlockBuilder addBeforeEach(Optional<String> description, HookFunction function) {
-        beforeEachHooks.add(new Hook(description, function));
+        beforeEachHooks.add(new Hook(BEFORE_EACH, description, function));
         return this;
     }
 
     TestBlockBuilder addAfterEach(Optional<String> description, HookFunction function) {
-        afterEachHooks.add(new Hook(description, function));
+        afterEachHooks.add(new Hook(AFTER_EACH, description, function));
         return this;
     }
 
@@ -76,7 +80,7 @@ final class TestBlockBuilder {
     }
 
     TestBlock build() {
-        return new TestBlock(behaviour, description, testBlocks, beforeHooks, afterAfter, beforeEachHooks,
+        return new TestBlock(behaviour, testClass, description, testBlocks, beforeHooks, afterAfter, beforeEachHooks,
                 afterEachHooks, tests, options);
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.forgerock.cuppa.Cuppa;
 import org.forgerock.cuppa.CuppaException;
 import org.forgerock.cuppa.TestBuilder;
 import org.forgerock.cuppa.functions.HookFunction;
@@ -74,7 +75,7 @@ public enum TestContainer {
      */
     void describe(Behaviour behaviour, String description, TestBlockFunction function, Options options) {
         assertNotRunningTests("describe");
-        TestBlockBuilder testBlockBuilder = new TestBlockBuilder(behaviour, description, options);
+        TestBlockBuilder testBlockBuilder = new TestBlockBuilder(behaviour, testClass, description, options);
         stack.addLast(testBlockBuilder);
         try {
             function.apply();
@@ -289,7 +290,7 @@ public enum TestContainer {
      */
     public void reset() {
         runningTests = false;
-        rootBuilder = new TestBlockBuilder(NORMAL, "", new Options());
+        rootBuilder = new TestBlockBuilder(NORMAL, Cuppa.class, "", new Options());
         stack = new ArrayDeque<>();
         stack.addLast(rootBuilder);
         testClass = null;

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Hook.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Hook.java
@@ -28,6 +28,11 @@ import org.forgerock.cuppa.functions.HookFunction;
 public final class Hook {
 
     /**
+     * The type of the hook.
+     */
+    public final HookType type;
+
+    /**
      * An optional description.
      */
     public final Optional<String> description;
@@ -40,12 +45,15 @@ public final class Hook {
     /**
      * Constructs a new hook.
      *
+     * @param type The type of the hook.
      * @param description An optional description.
      * @param function A function to be executed (possibly more than once).
      */
-    public Hook(Optional<String> description, HookFunction function) {
+    public Hook(HookType type, Optional<String> description, HookFunction function) {
+        Objects.requireNonNull(type, "Hook must have a type");
         Objects.requireNonNull(description, "Hook must have a description");
         Objects.requireNonNull(function, "Hook must have a function");
+        this.type = type;
         this.description = description;
         this.function = function;
     }
@@ -61,19 +69,21 @@ public final class Hook {
 
         Hook hook = (Hook) o;
 
-        return Objects.equals(description, hook.description)
+        return Objects.equals(type, hook.type)
+            && Objects.equals(description, hook.description)
             && Objects.equals(function, hook.function);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(description, function);
+        return Objects.hash(type, description, function);
     }
 
     @Override
     public String toString() {
         return "Hook{"
-            + (description.isPresent() ? "description='" + description.get() + '\'' : "")
+            + "type=" + type
+            + (description.isPresent() ? ",description='" + description.get() + '\'' : "")
             + '}';
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/HookType.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/HookType.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.model;
+
+/**
+ * Hook type.
+ *
+ * @see Hook
+ */
+public enum HookType {
+    /**
+     * Run once before all tests in the current and nested blocks.
+     */
+    BEFORE,
+
+    /**
+     * Run before each test in the current and nested blocks.
+     */
+    BEFORE_EACH,
+
+    /**
+     * Run after each test in the current and nested blocks.
+     */
+    AFTER_EACH,
+
+    /**
+     * Run once after all tests in the current and nested blocks.
+     */
+    AFTER
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
@@ -18,6 +18,7 @@ package org.forgerock.cuppa.model;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 
@@ -50,22 +51,7 @@ public final class TestBlock {
     /**
      * Before hooks. Will be run once before any tests in this test block are executed.
      */
-    public final ImmutableList<Hook> beforeHooks;
-
-    /**
-     * After hooks. Will be run once after all tests in this test block are executed.
-     */
-    public final ImmutableList<Hook> afterHooks;
-
-    /**
-     * Before each hooks. Will run before each test in this test block is executed.
-     */
-    public final ImmutableList<Hook> beforeEachHooks;
-
-    /**
-     * After each hooks. Will run after each test in this test block is executed.
-     */
-    public final ImmutableList<Hook> afterEachHooks;
+    public final ImmutableList<Hook> hooks;
 
     /**
      * Nested tests.
@@ -84,34 +70,24 @@ public final class TestBlock {
      * @param testClass The class that the test block was defined in.
      * @param description The description of the test block. Will be used for reporting.
      * @param testBlocks Nested test blocks.
-     * @param beforeHooks Before hooks. Will be run once before any tests in this test block are executed.
-     * @param afterHooks After hooks. Will be run once after all tests in this test block are executed.
-     * @param beforeEachHooks Before each hooks. Will run before each test in this test block is executed.
-     * @param afterEachHooks After each hooks. Will run after each test in this test block is executed.
+     * @param hooks Hooks associated with this test block.
      * @param tests Nested tests.
      * @param options The set of options applied to the block.
      */
     public TestBlock(Behaviour behaviour, Class<?> testClass, String description, List<TestBlock> testBlocks,
-            List<Hook> beforeHooks, List<Hook> afterHooks, List<Hook> beforeEachHooks, List<Hook> afterEachHooks,
-            List<Test> tests, Options options) {
+            List<Hook> hooks, List<Test> tests, Options options) {
         Objects.requireNonNull(behaviour, "TestBlock must have a behaviour");
         Objects.requireNonNull(testClass, "TestBlock must have a testClass");
         Objects.requireNonNull(description, "TestBlock must have a description");
         Objects.requireNonNull(testBlocks, "TestBlock must have testBlocks");
-        Objects.requireNonNull(beforeHooks, "TestBlock must have beforeHooks");
-        Objects.requireNonNull(afterHooks, "TestBlock must have afterHook");
-        Objects.requireNonNull(beforeEachHooks, "TestBlock must have beforeEachHooks");
-        Objects.requireNonNull(afterEachHooks, "TestBlock must have afterEachHooks");
+        Objects.requireNonNull(hooks, "TestBlock must have hooks");
         Objects.requireNonNull(tests, "TestBlock must have tests");
         Objects.requireNonNull(options, "TestBlock must have options");
         this.behaviour = behaviour;
         this.testClass = testClass;
         this.description = description;
         this.testBlocks = ImmutableList.copyOf(testBlocks);
-        this.beforeHooks = ImmutableList.copyOf(beforeHooks);
-        this.afterHooks = ImmutableList.copyOf(afterHooks);
-        this.beforeEachHooks = ImmutableList.copyOf(beforeEachHooks);
-        this.afterEachHooks = ImmutableList.copyOf(afterEachHooks);
+        this.hooks = ImmutableList.copyOf(hooks);
         this.tests = ImmutableList.copyOf(tests);
         this.options = Options.immutableCopyOf(options);
     }
@@ -131,18 +107,14 @@ public final class TestBlock {
             && Objects.equals(testClass, testBlock.testClass)
             && Objects.equals(description, testBlock.description)
             && Objects.equals(testBlocks, testBlock.testBlocks)
-            && Objects.equals(beforeHooks, testBlock.beforeHooks)
-            && Objects.equals(afterHooks, testBlock.afterHooks)
-            && Objects.equals(beforeEachHooks, testBlock.beforeEachHooks)
-            && Objects.equals(afterEachHooks, testBlock.afterEachHooks)
+            && Objects.equals(hooks, testBlock.hooks)
             && Objects.equals(tests, testBlock.tests)
             && Objects.equals(options, testBlock.options);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(behaviour, testClass, description, testBlocks, beforeHooks, afterHooks, beforeEachHooks,
-                afterEachHooks, tests, options);
+        return Objects.hash(behaviour, testClass, description, testBlocks, hooks, tests, options);
     }
 
     @Override
@@ -152,12 +124,21 @@ public final class TestBlock {
             + ", testClass=" + testClass
             + ", description='" + description + '\''
             + ", testBlocks=" + testBlocks
-            + ", beforeHooks=" + beforeHooks
-            + ", afterHooks=" + afterHooks
-            + ", beforeEachHooks=" + beforeEachHooks
-            + ", afterEachHooks=" + afterEachHooks
+            + ", hooks=" + hooks
             + ", tests=" + tests
             + ", options=" + options
             + '}';
+    }
+
+    /**
+     * Get all the registered hooks of the given type, in the order they were defined.
+     *
+     * @param type The type of hook to filter on.
+     * @return An immutable list of hooks.
+     */
+    public ImmutableList<Hook> hooksOfType(HookType type) {
+        return hooks.stream()
+                .filter(h -> h.type == type)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf));
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
@@ -33,6 +33,11 @@ public final class TestBlock {
     public final Behaviour behaviour;
 
     /**
+     * The class that the test block was defined in.
+     */
+    public final Class<?> testClass;
+
+    /**
      * The description of the test block. Will be used for reporting.
      */
     public final String description;
@@ -76,6 +81,7 @@ public final class TestBlock {
      * Constructs a new TestBlock. Will convert mutable lists to immutable lists.
      *
      * @param behaviour Controls how the test block and its descendants behave.
+     * @param testClass The class that the test block was defined in.
      * @param description The description of the test block. Will be used for reporting.
      * @param testBlocks Nested test blocks.
      * @param beforeHooks Before hooks. Will be run once before any tests in this test block are executed.
@@ -85,10 +91,11 @@ public final class TestBlock {
      * @param tests Nested tests.
      * @param options The set of options applied to the block.
      */
-    public TestBlock(Behaviour behaviour, String description, List<TestBlock> testBlocks, List<Hook> beforeHooks,
-            List<Hook> afterHooks, List<Hook> beforeEachHooks, List<Hook> afterEachHooks, List<Test> tests,
-            Options options) {
+    public TestBlock(Behaviour behaviour, Class<?> testClass, String description, List<TestBlock> testBlocks,
+            List<Hook> beforeHooks, List<Hook> afterHooks, List<Hook> beforeEachHooks, List<Hook> afterEachHooks,
+            List<Test> tests, Options options) {
         Objects.requireNonNull(behaviour, "TestBlock must have a behaviour");
+        Objects.requireNonNull(testClass, "TestBlock must have a testClass");
         Objects.requireNonNull(description, "TestBlock must have a description");
         Objects.requireNonNull(testBlocks, "TestBlock must have testBlocks");
         Objects.requireNonNull(beforeHooks, "TestBlock must have beforeHooks");
@@ -98,6 +105,7 @@ public final class TestBlock {
         Objects.requireNonNull(tests, "TestBlock must have tests");
         Objects.requireNonNull(options, "TestBlock must have options");
         this.behaviour = behaviour;
+        this.testClass = testClass;
         this.description = description;
         this.testBlocks = ImmutableList.copyOf(testBlocks);
         this.beforeHooks = ImmutableList.copyOf(beforeHooks);
@@ -120,6 +128,7 @@ public final class TestBlock {
         TestBlock testBlock = (TestBlock) o;
 
         return Objects.equals(behaviour, testBlock.behaviour)
+            && Objects.equals(testClass, testBlock.testClass)
             && Objects.equals(description, testBlock.description)
             && Objects.equals(testBlocks, testBlock.testBlocks)
             && Objects.equals(beforeHooks, testBlock.beforeHooks)
@@ -132,7 +141,7 @@ public final class TestBlock {
 
     @Override
     public int hashCode() {
-        return Objects.hash(behaviour, description, testBlocks, beforeHooks, afterHooks, beforeEachHooks,
+        return Objects.hash(behaviour, testClass, description, testBlocks, beforeHooks, afterHooks, beforeEachHooks,
                 afterEachHooks, tests, options);
     }
 
@@ -140,6 +149,7 @@ public final class TestBlock {
     public String toString() {
         return "TestBlock{"
             + "behaviour=" + behaviour
+            + ", testClass=" + testClass
             + ", description='" + description + '\''
             + ", testBlocks=" + testBlocks
             + ", beforeHooks=" + beforeHooks

--- a/cuppa/src/main/java/org/forgerock/cuppa/reporters/DefaultReporter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/reporters/DefaultReporter.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import org.forgerock.cuppa.ReporterSupport;
 import org.forgerock.cuppa.model.Hook;
+import org.forgerock.cuppa.model.HookType;
 import org.forgerock.cuppa.model.Test;
 import org.forgerock.cuppa.model.TestBlock;
 
@@ -116,6 +117,13 @@ public final class DefaultReporter implements Reporter {
 
     @Override
     public void hookError(Hook hook, Throwable cause) {
+        String description = "\"" + getHookType(hook.type) + "\" hook";
+        if (hook.description.isPresent()) {
+            description += " \"" + hook.description.get() + "\"";
+        }
+        failed++;
+        failures.add(new TestFailure(String.join(" ", blockStack) + " " + description, cause));
+        stream.println(getIndent() + failures.size() + ") " + description);
     }
 
     @Override
@@ -158,6 +166,21 @@ public final class DefaultReporter implements Reporter {
 
     private String getIndent() {
         return Stream.generate(() -> "  ").limit(blockStack.size()).collect(Collectors.joining());
+    }
+
+    private String getHookType(HookType type) {
+        switch (type) {
+            case BEFORE:
+                return "before";
+            case BEFORE_EACH:
+                return "before each";
+            case AFTER_EACH:
+                return "after each";
+            case AFTER:
+                return "after";
+            default:
+                throw new IllegalStateException("unknown hook type");
+        }
     }
 
     private static final class TestFailure {

--- a/cuppa/src/test/java/org/forgerock/cuppa/ModelFinder.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/ModelFinder.java
@@ -89,11 +89,6 @@ public final class ModelFinder {
     }
 
     private static Stream<Hook> getHooks(TestBlock block) {
-        Stream<Hook> hooks = concat(block.beforeHooks.stream(),
-                concat(block.afterHooks.stream(),
-                concat(block.beforeEachHooks.stream(),
-                block.afterEachHooks.stream())));
-        Stream<Hook> nestedHooks = block.testBlocks.stream().flatMap(ModelFinder::getHooks);
-        return concat(hooks, nestedHooks);
+        return concat(block.hooks.stream(), block.testBlocks.stream().flatMap(ModelFinder::getHooks));
     }
 }

--- a/cuppa/src/test/java/org/forgerock/cuppa/reporters/DefaultReporterTest.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/reporters/DefaultReporterTest.java
@@ -282,4 +282,86 @@ public class DefaultReporterTest extends AbstractTest {
         String expectedOutput = String.join(System.lineSeparator(), expectedLines);
         assertThat(output).startsWith(expectedOutput);
     }
+
+    @Test
+    public void reporterShouldReportFailingHooks() {
+
+        //Given
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Reporter reporter = new DefaultReporter(outputStream);
+        {
+            describe("describe", () -> {
+                when("when", () -> {
+                    beforeEach(() -> {
+                        throw new RuntimeException();
+                    });
+                    it("passing test", () -> {
+                    });
+                });
+            });
+        }
+
+        //When
+        runTests(reporter);
+
+        //Then
+        String output = new String(outputStream.toByteArray(), UTF_8);
+        String[] expectedLines = {
+                "",
+                "",
+                "  describe",
+                "    when when",
+                "      1) \"before each\" hook",
+                "",
+                "",
+                "  0 passing",
+                "  1 failing",
+                "",
+                "  1) describe when when \"before each\" hook:",
+                "     java.lang.RuntimeException",
+        };
+        String expectedOutput = String.join(System.lineSeparator(), expectedLines);
+        assertThat(output).startsWith(expectedOutput);
+    }
+
+    @Test
+    public void reporterShouldReportFailingNamedHook() {
+
+        //Given
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Reporter reporter = new DefaultReporter(outputStream);
+        {
+            describe("describe", () -> {
+                when("when", () -> {
+                    beforeEach("my hook", () -> {
+                        throw new RuntimeException();
+                    });
+                    it("passing test", () -> {
+                    });
+                });
+            });
+        }
+
+        //When
+        runTests(reporter);
+
+        //Then
+        String output = new String(outputStream.toByteArray(), UTF_8);
+        String[] expectedLines = {
+                "",
+                "",
+                "  describe",
+                "    when when",
+                "      1) \"before each\" hook \"my hook\"",
+                "",
+                "",
+                "  0 passing",
+                "  1 failing",
+                "",
+                "  1) describe when when \"before each\" hook \"my hook\":",
+                "     java.lang.RuntimeException",
+        };
+        String expectedOutput = String.join(System.lineSeparator(), expectedLines);
+        assertThat(output).startsWith(expectedOutput);
+    }
 }


### PR DESCRIPTION
We weren't really reporting hook errors, but they're actually very common so it's important we do.

The second commit is an optional refactor that I'd like to get your thoughts on. The motivation was to reduce the number of parameters on the `TestBlock` constructor, making it easier to write block transforms.