### PR TITLE
Remove test error state

### DIFF
--- a/cuppa-junit/src/main/java/org/forgerock/cuppa/junit/ReportJUnitAdapter.java
+++ b/cuppa-junit/src/main/java/org/forgerock/cuppa/junit/ReportJUnitAdapter.java
@@ -97,13 +97,7 @@ final class ReportJUnitAdapter implements Reporter {
     }
 
     @Override
-    public void testFail(Test test, AssertionError e) {
-        ReporterSupport.filterStackTrace(e);
-        notifier.fireTestFailure(new Failure(getDescription(test.description), e));
-    }
-
-    @Override
-    public void testError(Test test, Throwable e) {
+    public void testFail(Test test, Throwable e) {
         ReporterSupport.filterStackTrace(e);
         notifier.fireTestFailure(new Failure(getDescription(test.description), e));
     }

--- a/cuppa-surefire/src/main/java/org/forgerock/cuppa/maven/surefire/CuppaSurefireReporter.java
+++ b/cuppa-surefire/src/main/java/org/forgerock/cuppa/maven/surefire/CuppaSurefireReporter.java
@@ -97,18 +97,10 @@ final class CuppaSurefireReporter implements Reporter {
     }
 
     @Override
-    public void testFail(Test test, AssertionError cause) {
+    public void testFail(Test test, Throwable cause) {
         ReporterSupport.filterStackTrace(cause);
         String description = getFullDescription(test.description);
         listener.testFailed(new SimpleReportEntry(test.testClass.getCanonicalName(), description,
-                new PojoStackTraceWriter(test.testClass.getCanonicalName(), description, cause), 0));
-    }
-
-    @Override
-    public void testError(Test test, Throwable cause) {
-        ReporterSupport.filterStackTrace(cause);
-        String description = getFullDescription(test.description);
-        listener.testError(new SimpleReportEntry(test.testClass.getCanonicalName(), description,
                 new PojoStackTraceWriter(test.testClass.getCanonicalName(), description, cause), 0));
     }
 

--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -175,10 +175,8 @@ public final class Runner {
                 reporter.testStart(test);
                 test.function.get().apply();
                 reporter.testPass(test);
-            } catch (AssertionError e) {
-                reporter.testFail(test, e);
             } catch (Throwable e) {
-                reporter.testError(test, e);
+                reporter.testFail(test, e);
             } finally {
                 reporter.testEnd(test);
             }

--- a/cuppa/src/main/java/org/forgerock/cuppa/reporters/DefaultReporter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/reporters/DefaultReporter.java
@@ -141,15 +141,10 @@ public final class DefaultReporter implements Reporter {
     }
 
     @Override
-    public void testError(Test test, Throwable cause) {
+    public void testFail(Test test, Throwable cause) {
         failed++;
         failures.add(new TestFailure(String.join(" ", blockStack) + " " + test.description, cause));
         stream.println(getIndent() + failures.size() + ") " + test.description);
-    }
-
-    @Override
-    public void testFail(Test test, AssertionError cause) {
-        testError(test, cause);
     }
 
     @Override

--- a/cuppa/src/main/java/org/forgerock/cuppa/reporters/Reporter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/reporters/Reporter.java
@@ -79,20 +79,12 @@ public interface Reporter {
     void testPass(Test test);
 
     /**
-     * Called after a test has failed due to throwing a assertion error.
+     * Called after a test has failed due to it throwing an exception.
      *
      * @param test The test that failed.
      * @param cause The assertion error that the test threw.
      */
-    void testFail(Test test, AssertionError cause);
-
-    /**
-     * Called after a test has failed due to throwing an exception that wasn't an assertion error.
-     *
-     * @param test The test that threw an exception.
-     * @param cause The throwable that the test threw.
-     */
-    void testError(Test test, Throwable cause);
+    void testFail(Test test, Throwable cause);
 
     /**
      * Called when a test cannot be run as it has not yet been implemented.

--- a/cuppa/src/test/java/org/forgerock/cuppa/BasicApiTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/BasicApiTests.java
@@ -151,7 +151,7 @@ public class BasicApiTests extends AbstractTest {
     }
 
     @Test
-    public void basicApiUsageShouldReportTestErrorWithDescribeBlockNestedUnderItBlock() {
+    public void basicApiUsageShouldReportTestFailureWithDescribeBlockNestedUnderItBlock() {
 
         //Given
         Reporter reporter = mock(Reporter.class);
@@ -170,11 +170,11 @@ public class BasicApiTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(eq(findTest("runs the test, which errors")), isA(CuppaException.class));
+        verify(reporter).testFail(eq(findTest("runs the test, which errors")), isA(CuppaException.class));
     }
 
     @Test
-    public void basicApiUsageShouldReportTestErrorWithWhenNestedUnderItBlock() {
+    public void basicApiUsageShouldReportTestFailureWithWhenNestedUnderItBlock() {
 
         //Given
         Reporter reporter = mock(Reporter.class);
@@ -193,11 +193,11 @@ public class BasicApiTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(eq(findTest("runs the test, which errors")), isA(CuppaException.class));
+        verify(reporter).testFail(eq(findTest("runs the test, which errors")), isA(CuppaException.class));
     }
 
     @Test
-    public void basicApiUsageShouldRunTestsAfterErroredTest() {
+    public void basicApiUsageShouldRunTestsAfterFailedTest() {
 
         //Given
         Reporter reporter = mock(Reporter.class);
@@ -218,7 +218,7 @@ public class BasicApiTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(eq(findTest("runs the first test, which errors")), isA(Throwable.class));
+        verify(reporter).testFail(eq(findTest("runs the first test, which errors")), isA(Throwable.class));
         verify(reporter).testPass(findTest("runs the second test, which passes"));
     }
 
@@ -227,34 +227,11 @@ public class BasicApiTests extends AbstractTest {
 
         //Given
         Reporter reporter = mock(Reporter.class);
-        AssertionError assertionError = new AssertionError();
+        RuntimeException exception = new RuntimeException();
         {
             describe("basic API usage", () -> {
                 when("the 'when' block is run", () -> {
                     it("runs the test, which fails", () -> {
-                        throw assertionError;
-                    });
-                });
-            });
-        }
-
-        //When
-        runTests(reporter);
-
-        //Then
-        verify(reporter).testFail(eq(findTest("runs the test, which fails")), any(AssertionError.class));
-    }
-
-    @Test
-    public void basicApiUsageWithSingleErroredTest() {
-
-        //Given
-        Reporter reporter = mock(Reporter.class);
-        IllegalStateException exception = new IllegalStateException();
-        {
-            describe("basic API usage", () -> {
-                when("the 'when' block is run", () -> {
-                    it("runs the test, which errors", () -> {
                         throw exception;
                     });
                 });
@@ -265,26 +242,22 @@ public class BasicApiTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(findTest("runs the test, which errors"), exception);
+        verify(reporter).testFail(eq(findTest("runs the test, which fails")), eq(exception));
     }
 
     @Test
-    public void basicApiUsageWithPassingFailingAndErroredTests() {
+    public void basicApiUsageWithPassingAndFailingTests() {
 
         //Given
         Reporter reporter = mock(Reporter.class);
         RuntimeException exception = new RuntimeException();
-        AssertionError assertionError = new AssertionError();
         {
             describe("basic API usage", () -> {
                 when("the 'when' block is run", () -> {
-                    it("runs the first test, which errors", () -> {
+                    it("runs the first test, which fails", () -> {
                         throw exception;
                     });
-                    it("runs the second test, which fails", () -> {
-                        throw assertionError;
-                    });
-                    it("runs the third test, which passes", TestFunction.identity());
+                    it("runs the second test, which passes", TestFunction.identity());
                 });
             });
         }
@@ -293,9 +266,8 @@ public class BasicApiTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(eq(findTest("runs the first test, which errors")), any(Throwable.class));
-        verify(reporter).testFail(eq(findTest("runs the second test, which fails")), any(AssertionError.class));
-        verify(reporter).testPass(findTest("runs the third test, which passes"));
+        verify(reporter).testFail(eq(findTest("runs the first test, which fails")), any(Throwable.class));
+        verify(reporter).testPass(findTest("runs the second test, which passes"));
     }
 
     @Test
@@ -318,6 +290,6 @@ public class BasicApiTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(findTest("runs the test"), exception);
+        verify(reporter).testFail(findTest("runs the test"), exception);
     }
 }

--- a/cuppa/src/test/java/org/forgerock/cuppa/HookExceptionTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/HookExceptionTests.java
@@ -721,7 +721,7 @@ public class HookExceptionTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(eq(findTest("will cause the test to throw an error")), isA(CuppaException.class));
+        verify(reporter).testFail(eq(findTest("will cause the test to throw an error")), isA(CuppaException.class));
     }
 
     @DataProvider

--- a/cuppa/src/test/java/org/forgerock/cuppa/ReportingTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/ReportingTests.java
@@ -89,27 +89,6 @@ public class ReportingTests extends AbstractTest {
 
         //Given
         Reporter reporter = mock(Reporter.class);
-        AssertionError assertionError = new AssertionError();
-        {
-            describe("describe", () -> {
-                it("test", () -> {
-                    throw assertionError;
-                });
-            });
-        }
-
-        //When
-        runTests(reporter);
-
-        //Then
-        verify(reporter).testFail(findTest("test"), assertionError);
-    }
-
-    @Test
-    public void reporterShouldBeNotifiedOfErroredTest() {
-
-        //Given
-        Reporter reporter = mock(Reporter.class);
         IllegalStateException exception = new IllegalStateException();
         {
             describe("describe", () -> {
@@ -123,7 +102,7 @@ public class ReportingTests extends AbstractTest {
         runTests(reporter);
 
         //Then
-        verify(reporter).testError(findTest("test"), exception);
+        verify(reporter).testFail(findTest("test"), exception);
     }
 
     @Test


### PR DESCRIPTION
We introduced the distinction between fail and error in an attempt to be consistent with other Java test frameworks. Since JUnit 4 no longer makes this distinction, and the distinction is not common in other RSpec-style frameworks, we now feel that the it is unnecessary. Removing it simplifies Cuppa.

Fixes #63