### PR TITLE
Improve Cuppa's use of exceptions

### DIFF
--- a/cuppa/src/main/java/org/forgerock/cuppa/CuppaException.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/CuppaException.java
@@ -17,17 +17,27 @@
 package org.forgerock.cuppa;
 
 /**
- * Thrown to indicate that a failure whilst running Cuppa tests.
+ * Thrown to indicate that an error occurred whilst running Cuppa tests.
  */
 public final class CuppaException extends RuntimeException {
 
     /**
-     * Constructs a new Cuppa exception with the specified cause.
+     * Constructs a new Cuppa exception with the given message and cause.
      *
+     * @param message the String that contains a detailed message.
      * @param cause The cause. (A {@code null} value is permitted, and indicates that the cause
      *         is nonexistent or unknown.)
      */
-    public CuppaException(Throwable cause) {
-        super(cause);
+    public CuppaException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new Cuppa exception with the given message.
+     *
+     * @param message the String that contains a detailed message.
+     */
+    public CuppaException(String message) {
+        super(message);
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -109,7 +109,7 @@ public final class Runner {
             } catch (CuppaException e) {
                 throw e;
             } catch (Exception e) {
-                throw new IllegalStateException("Must be able to instantiate test class", e);
+                throw new CuppaException("Failed to instantiate test class", e);
             }
         }
         return TestContainer.INSTANCE.getRootTestBlock();
@@ -121,7 +121,7 @@ public final class Runner {
         if (iterator.hasNext()) {
             ConfigurationProvider configurationProvider = iterator.next();
             if (iterator.hasNext()) {
-                throw new IllegalStateException("There must only be a single configuration provider available on the"
+                throw new CuppaException("There must only be a single configuration provider available on the "
                         + "classpath");
             }
             configurationProvider.configure(configuration);

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
@@ -92,6 +92,7 @@ public enum TestContainer {
      * @param function The 'when' block.
      */
     public void when(String description, TestBlockFunction function) {
+        assertNotRunningTests("when");
         new TestBuilderImpl().when(description, function);
     }
 
@@ -112,7 +113,7 @@ public enum TestContainer {
      */
     public void before(String description, HookFunction function) {
         assertNotRunningTests("before");
-        assertNotRootDescribeBlock("when", "describe");
+        assertNotRootDescribeBlock("before");
         getCurrentDescribeBlock().addBefore(Optional.ofNullable(description), function);
     }
 
@@ -133,7 +134,7 @@ public enum TestContainer {
      */
     public void after(String description, HookFunction function) {
         assertNotRunningTests("after");
-        assertNotRootDescribeBlock("when", "describe");
+        assertNotRootDescribeBlock("after");
         getCurrentDescribeBlock().addAfter(Optional.ofNullable(description), function);
     }
 
@@ -154,7 +155,7 @@ public enum TestContainer {
      */
     public void beforeEach(String description, HookFunction function) {
         assertNotRunningTests("beforeEach");
-        assertNotRootDescribeBlock("when", "describe");
+        assertNotRootDescribeBlock("beforeEach");
         getCurrentDescribeBlock().addBeforeEach(Optional.ofNullable(description), function);
     }
 
@@ -175,7 +176,7 @@ public enum TestContainer {
      */
     public void afterEach(String description, HookFunction function) {
         assertNotRunningTests("afterEach");
-        assertNotRootDescribeBlock("when", "describe");
+        assertNotRootDescribeBlock("afterEach");
         getCurrentDescribeBlock().addAfterEach(Optional.ofNullable(description), function);
     }
 
@@ -211,7 +212,7 @@ public enum TestContainer {
      */
     public void it(Behaviour behaviour, String description, Optional<TestFunction> function, Options options) {
         assertNotRunningTests("it");
-        assertNotRootDescribeBlock("it", "when", "describe");
+        assertNotRootDescribeBlock("it");
         getCurrentDescribeBlock().addTest(new Test(behaviour, testClass, description, function, options));
     }
 
@@ -298,15 +299,13 @@ public enum TestContainer {
 
     private void assertNotRunningTests(String blockType) {
         if (runningTests) {
-            throw new CuppaException(new IllegalStateException("Cannot declare new '" + blockType
-                    + "' block whilst running tests"));
+            throw new CuppaException("'" + blockType + "' may only be nested within a 'describe' or 'when' block");
         }
     }
 
-    private void assertNotRootDescribeBlock(String blockType, String... allowedBlockTypes) {
+    private void assertNotRootDescribeBlock(String blockType) {
         if (getCurrentDescribeBlock().equals(rootBuilder)) {
-            throw new CuppaException(new IllegalStateException("A '" + blockType + "' must be nested within a "
-                    + String.join(", ", allowedBlockTypes) + " function"));
+            throw new CuppaException("'" + blockType + "' must be nested within a 'describe' or 'when' block");
         }
     }
 


### PR DESCRIPTION
This change improves the test coverage of the exceptions thrown by Cuppa and fixes several bugs uncovered by the improvements.