### PR TITLE
Add basic Intellij IDEA plugin

### DIFF
--- a/cuppa-intellij/build.gradle
+++ b/cuppa-intellij/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "org.jetbrains.intellij" version "0.0.43"
+}
+
+group 'org.forgerock.cuppa'
+version '0.9.0-SNAPSHOT'
+
+apply plugin: 'java'
+apply plugin: 'org.jetbrains.intellij'
+
+intellij {
+    version '2016.1'
+    pluginName 'Cuppa'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '4.11'
+}

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaCantBeStaticExtension.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaCantBeStaticExtension.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.intellij;
+
+import com.intellij.codeInsight.AnnotationUtil;
+import com.intellij.openapi.util.Condition;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiClassInitializer;
+import com.intellij.psi.PsiElement;
+
+/**
+ * Extension to prevent the "Class initializer may be 'static'" inspection from
+ * marking the non-static class initializer block in Cuppa test classes.
+ */
+public final class CuppaCantBeStaticExtension implements Condition<PsiElement> {
+    @Override
+    public boolean value(PsiElement psiElement) {
+        if (psiElement instanceof PsiClassInitializer) {
+            PsiClass containingClass = ((PsiClassInitializer) psiElement).getContainingClass();
+            if (containingClass == null) {
+                return false;
+            }
+            if (AnnotationUtil.isAnnotated(containingClass, "org.forgerock.cuppa.Test", true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaCantBeStaticExtension.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaCantBeStaticExtension.java
@@ -16,9 +16,7 @@
 
 package org.forgerock.cuppa.intellij;
 
-import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.openapi.util.Condition;
-import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassInitializer;
 import com.intellij.psi.PsiElement;
 
@@ -29,15 +27,6 @@ import com.intellij.psi.PsiElement;
 public final class CuppaCantBeStaticExtension implements Condition<PsiElement> {
     @Override
     public boolean value(PsiElement psiElement) {
-        if (psiElement instanceof PsiClassInitializer) {
-            PsiClass containingClass = ((PsiClassInitializer) psiElement).getContainingClass();
-            if (containingClass == null) {
-                return false;
-            }
-            if (AnnotationUtil.isAnnotated(containingClass, "org.forgerock.cuppa.Test", true)) {
-                return true;
-            }
-        }
-        return false;
+        return psiElement instanceof PsiClassInitializer && CuppaUtils.isCuppaClass(psiElement);
     }
 }

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaEntryPoint.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaEntryPoint.java
@@ -16,7 +16,6 @@
 
 package org.forgerock.cuppa.intellij;
 
-import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInspection.reference.EntryPoint;
 import com.intellij.codeInspection.reference.RefElement;
 import com.intellij.openapi.util.InvalidDataException;
@@ -51,16 +50,7 @@ public final class CuppaEntryPoint extends EntryPoint {
 
     @Override
     public boolean isEntryPoint(@NotNull PsiElement psiElement) {
-        if (!isSelected) {
-            return false;
-        }
-        if (psiElement instanceof PsiClass) {
-            PsiClass clazz = (PsiClass) psiElement;
-            if (AnnotationUtil.isAnnotated(clazz, "org.forgerock.cuppa.Test", true)) {
-                return true;
-            }
-        }
-        return false;
+        return isSelected && psiElement instanceof PsiClass && CuppaUtils.isCuppaClass(psiElement);
     }
 
     @Override

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaEntryPoint.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaEntryPoint.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.intellij;
+
+import com.intellij.codeInsight.AnnotationUtil;
+import com.intellij.codeInspection.reference.EntryPoint;
+import com.intellij.codeInspection.reference.RefElement;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.WriteExternalException;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.xmlb.XmlSerializer;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Extension to prevent the "Unused declaration" inspection from marking
+ * a Cuppa test class as unused.
+ *
+ * <p>This class is also used by the "Unused declaration" inspection's
+ * settings dialog, where the user can select whether or not this entry
+ * point should be used.</p>
+ */
+public final class CuppaEntryPoint extends EntryPoint {
+    private boolean isSelected = true;
+
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Cuppa test classes";
+    }
+
+    @Override
+    public boolean isEntryPoint(@NotNull RefElement refElement, @NotNull PsiElement psiElement) {
+        return isEntryPoint(psiElement);
+    }
+
+    @Override
+    public boolean isEntryPoint(@NotNull PsiElement psiElement) {
+        if (!isSelected) {
+            return false;
+        }
+        if (psiElement instanceof PsiClass) {
+            PsiClass clazz = (PsiClass) psiElement;
+            if (AnnotationUtil.isAnnotated(clazz, "org.forgerock.cuppa.Test", true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isSelected() {
+        return isSelected;
+    }
+
+    @Override
+    public void setSelected(boolean selected) {
+        isSelected = selected;
+    }
+
+    @Override
+    public void readExternal(Element element) throws InvalidDataException {
+        XmlSerializer.serializeInto(this, element);
+    }
+
+    @Override
+    public void writeExternal(Element element) throws WriteExternalException {
+        if (!isSelected) {
+            XmlSerializer.deserializeInto(this, element);
+        }
+    }
+}

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaLiveTemplateContext.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaLiveTemplateContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.intellij;
+
+import com.intellij.codeInsight.AnnotationUtil;
+import com.intellij.codeInsight.template.JavaCodeContextType;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Extension to provide a context for Cuppa live templates so that they are only
+ * available in statements in Cuppa test classes.
+ */
+public final class CuppaLiveTemplateContext extends JavaCodeContextType {
+    private final Statement statement = new Statement();
+
+    /**
+     * Constructs a new context.
+     */
+    public CuppaLiveTemplateContext() {
+        super("CUPPA_TEST_STATEMENT", "Cuppa test class", Statement.class);
+    }
+
+    @Override
+    public boolean isInContext(@NotNull PsiFile file, int offset) {
+        if (!statement.isInContext(file, offset)) {
+            return false;
+        }
+        return super.isInContext(file, offset);
+    }
+
+    @Override
+    protected boolean isInContext(@NotNull PsiElement element) {
+        PsiClass containingClass = PsiTreeUtil.getParentOfType(element, PsiClass.class);
+        if (containingClass != null) {
+            return AnnotationUtil.isAnnotated(containingClass, "org.forgerock.cuppa.Test", true);
+        }
+        return false;
+    }
+}

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaLiveTemplateContext.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaLiveTemplateContext.java
@@ -16,12 +16,9 @@
 
 package org.forgerock.cuppa.intellij;
 
-import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.template.JavaCodeContextType;
-import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -40,18 +37,11 @@ public final class CuppaLiveTemplateContext extends JavaCodeContextType {
 
     @Override
     public boolean isInContext(@NotNull PsiFile file, int offset) {
-        if (!statement.isInContext(file, offset)) {
-            return false;
-        }
-        return super.isInContext(file, offset);
+        return statement.isInContext(file, offset) && super.isInContext(file, offset);
     }
 
     @Override
     protected boolean isInContext(@NotNull PsiElement element) {
-        PsiClass containingClass = PsiTreeUtil.getParentOfType(element, PsiClass.class);
-        if (containingClass != null) {
-            return AnnotationUtil.isAnnotated(containingClass, "org.forgerock.cuppa.Test", true);
-        }
-        return false;
+        return CuppaUtils.isCuppaClass(element);
     }
 }

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaLiveTemplatesProvider.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaLiveTemplatesProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.intellij;
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Extension to provide Cuppa-specific live templates.
+ */
+public final class CuppaLiveTemplatesProvider implements DefaultLiveTemplatesProvider {
+    @Override
+    public String[] getDefaultLiveTemplateFiles() {
+        return new String[]{"liveTemplates/Cuppa"};
+    }
+
+    @Nullable
+    @Override
+    public String[] getHiddenLiveTemplateFiles() {
+        return null;
+    }
+}

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaUtils.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/CuppaUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.intellij;
+
+import com.intellij.codeInsight.AnnotationUtil;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+
+/**
+ * Utility functions for integrating with IntelliJ's APIs.
+ */
+final class CuppaUtils {
+    private static final String TEST_ANNOTATION_FQCN = "org.forgerock.cuppa.Test";
+
+    private CuppaUtils() {
+    }
+
+    /**
+     * Determine if the given PSI element is nested within a Java class annotated with Cuppa's Test annotation.
+     *
+     * @param psiElement The PSI element.
+     * @return true if the given element is nested in a Cuppa test class and false otherwise.
+     */
+    static boolean isCuppaClass(PsiElement psiElement) {
+        PsiClass psiClass = PsiTreeUtil.getParentOfType(psiElement, PsiClass.class, false);
+        return psiClass != null && AnnotationUtil.isAnnotated(psiClass, TEST_ANNOTATION_FQCN, true);
+    }
+}

--- a/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/package-info.java
+++ b/cuppa-intellij/src/main/java/org/forgerock/cuppa/intellij/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A plugin for IntelliJ IDEA that provides Cuppa integration.
+ */
+package org.forgerock.cuppa.intellij;

--- a/cuppa-intellij/src/main/resources/META-INF/plugin.xml
+++ b/cuppa-intellij/src/main/resources/META-INF/plugin.xml
@@ -27,5 +27,6 @@
         <stacktrace.fold substring="at org.forgerock.cuppa."/>
         <cantBeStatic implementation="org.forgerock.cuppa.intellij.CuppaCantBeStaticExtension"/>
         <deadCode implementation="org.forgerock.cuppa.intellij.CuppaEntryPoint"/>
+        <defaultLiveTemplatesProvider implementation="org.forgerock.cuppa.intellij.CuppaLiveTemplatesProvider"/>
     </extensions>
 </idea-plugin>

--- a/cuppa-intellij/src/main/resources/META-INF/plugin.xml
+++ b/cuppa-intellij/src/main/resources/META-INF/plugin.xml
@@ -28,5 +28,6 @@
         <cantBeStatic implementation="org.forgerock.cuppa.intellij.CuppaCantBeStaticExtension"/>
         <deadCode implementation="org.forgerock.cuppa.intellij.CuppaEntryPoint"/>
         <defaultLiveTemplatesProvider implementation="org.forgerock.cuppa.intellij.CuppaLiveTemplatesProvider"/>
+        <liveTemplateContext implementation="org.forgerock.cuppa.intellij.CuppaLiveTemplateContext"/>
     </extensions>
 </idea-plugin>

--- a/cuppa-intellij/src/main/resources/META-INF/plugin.xml
+++ b/cuppa-intellij/src/main/resources/META-INF/plugin.xml
@@ -25,5 +25,6 @@
     <depends>com.intellij.modules.java</depends>
     <extensions defaultExtensionNs="com.intellij">
         <stacktrace.fold substring="at org.forgerock.cuppa."/>
+        <cantBeStatic implementation="org.forgerock.cuppa.intellij.CuppaCantBeStaticExtension"/>
     </extensions>
 </idea-plugin>

--- a/cuppa-intellij/src/main/resources/META-INF/plugin.xml
+++ b/cuppa-intellij/src/main/resources/META-INF/plugin.xml
@@ -26,5 +26,6 @@
     <extensions defaultExtensionNs="com.intellij">
         <stacktrace.fold substring="at org.forgerock.cuppa."/>
         <cantBeStatic implementation="org.forgerock.cuppa.intellij.CuppaCantBeStaticExtension"/>
+        <deadCode implementation="org.forgerock.cuppa.intellij.CuppaEntryPoint"/>
     </extensions>
 </idea-plugin>

--- a/cuppa-intellij/src/main/resources/META-INF/plugin.xml
+++ b/cuppa-intellij/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 ForgeRock AS.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin version="2" url="http://cuppa.forgerock.org">
+    <name>Cuppa</name>
+    <id>org.forgerock.cuppa</id>
+    <description>
+        <![CDATA[
+        Integration with <a href="http://cuppa.forgerock.org">Cuppa</a>, a test framework for Java 8.
+        ]]></description>
+    <vendor url="http://forgerock.org">ForgeRock AS.</vendor>
+    <depends>com.intellij.modules.java</depends>
+    <extensions defaultExtensionNs="com.intellij">
+        <stacktrace.fold substring="at org.forgerock.cuppa."/>
+    </extensions>
+</idea-plugin>

--- a/cuppa-intellij/src/main/resources/liveTemplates/Cuppa.xml
+++ b/cuppa-intellij/src/main/resources/liveTemplates/Cuppa.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 ForgeRock AS.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<templateSet group="Cuppa">
+    <template name="a" value="org.forgerock.cuppa.Cuppa.after(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with an after block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+        <context>
+            <option name="JAVA_STATEMENT" value="true" />
+        </context>
+    </template>
+    <template name="ae" value="org.forgerock.cuppa.Cuppa.afterEach(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with an afterEach block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+        <context>
+            <option name="JAVA_STATEMENT" value="true" />
+        </context>
+    </template>
+    <template name="b" value="org.forgerock.cuppa.Cuppa.before(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a before block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+        <context>
+            <option name="JAVA_STATEMENT" value="true" />
+        </context>
+    </template>
+    <template name="be" value="org.forgerock.cuppa.Cuppa.beforeEach(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a beforeEach block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+        <context>
+            <option name="JAVA_STATEMENT" value="true" />
+        </context>
+    </template>
+    <template name="d" value="org.forgerock.cuppa.Cuppa.describe(&quot;$DESCRIPTION$&quot;, () -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a describe block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+        <variable name="DESCRIPTION" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="JAVA_STATEMENT" value="true" />
+        </context>
+    </template>
+    <template name="it" value="org.forgerock.cuppa.Cuppa.it(&quot;$DESCRIPTION$&quot;, () -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with an it block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+        <variable name="DESCRIPTION" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="JAVA_STATEMENT" value="true" />
+        </context>
+    </template>
+    <template name="w" value="org.forgerock.cuppa.Cuppa.when(&quot;$DESCRIPTION$&quot;, () -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a when block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+        <variable name="DESCRIPTION" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="JAVA_STATEMENT" value="true" />
+        </context>
+    </template>
+</templateSet>

--- a/cuppa-intellij/src/main/resources/liveTemplates/Cuppa.xml
+++ b/cuppa-intellij/src/main/resources/liveTemplates/Cuppa.xml
@@ -17,40 +17,40 @@
 <templateSet group="Cuppa">
     <template name="a" value="org.forgerock.cuppa.Cuppa.after(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with an after block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
         <context>
-            <option name="JAVA_STATEMENT" value="true" />
+            <option name="CUPPA_TEST_STATEMENT" value="true" />
         </context>
     </template>
     <template name="ae" value="org.forgerock.cuppa.Cuppa.afterEach(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with an afterEach block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
         <context>
-            <option name="JAVA_STATEMENT" value="true" />
+            <option name="CUPPA_TEST_STATEMENT" value="true" />
         </context>
     </template>
     <template name="b" value="org.forgerock.cuppa.Cuppa.before(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a before block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
         <context>
-            <option name="JAVA_STATEMENT" value="true" />
+            <option name="CUPPA_TEST_STATEMENT" value="true" />
         </context>
     </template>
     <template name="be" value="org.forgerock.cuppa.Cuppa.beforeEach(() -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a beforeEach block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
         <context>
-            <option name="JAVA_STATEMENT" value="true" />
+            <option name="CUPPA_TEST_STATEMENT" value="true" />
         </context>
     </template>
     <template name="d" value="org.forgerock.cuppa.Cuppa.describe(&quot;$DESCRIPTION$&quot;, () -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a describe block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
         <variable name="DESCRIPTION" expression="" defaultValue="" alwaysStopAt="true" />
         <context>
-            <option name="JAVA_STATEMENT" value="true" />
+            <option name="CUPPA_TEST_STATEMENT" value="true" />
         </context>
     </template>
     <template name="it" value="org.forgerock.cuppa.Cuppa.it(&quot;$DESCRIPTION$&quot;, () -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with an it block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
         <variable name="DESCRIPTION" expression="" defaultValue="" alwaysStopAt="true" />
         <context>
-            <option name="JAVA_STATEMENT" value="true" />
+            <option name="CUPPA_TEST_STATEMENT" value="true" />
         </context>
     </template>
     <template name="w" value="org.forgerock.cuppa.Cuppa.when(&quot;$DESCRIPTION$&quot;, () -&gt; {&#10;    $END$$SELECTION$&#10;});" description="Surround with a when block" toReformat="true" toShortenFQNames="true" useStaticImport="true">
         <variable name="DESCRIPTION" expression="" defaultValue="" alwaysStopAt="true" />
         <context>
-            <option name="JAVA_STATEMENT" value="true" />
+            <option name="CUPPA_TEST_STATEMENT" value="true" />
         </context>
     </template>
 </templateSet>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'cuppa-parent'
-include 'cuppa', 'cuppa-junit', 'cuppa-surefire'
+include 'cuppa', 'cuppa-junit', 'cuppa-surefire', 'cuppa-intellij'
+


### PR DESCRIPTION
The start of an IntelliJ IDEA plugin, which I think we should release ASAP as I think it adds value already.

Features introduced in this branch:

* Inclusion of live templates that are only active in Cuppa test classes.
* Prevent the "Unused declaration" inspection from marking Cuppa test classes as unused.
* Prevent the "class initializer can't be 'static'" inspection from marking the non-static class initialiser block in Cuppa test classes.

I'm not sure this should actually be checked into the main Cuppa repository because:

* It currently does not (and probably never should) depend on Cuppa.
* It will likely be versioned and released independently of Cuppa.
* It forces developers to download IntelliJ IDEA CE at build-time. That's a 200MB download.

I've already taken the liberty of submitted it to the plugin repository: https://plugins.jetbrains.com/plugin/8254