### PR TITLE
Allow configuration provider to set an additional reporter

### DIFF
--- a/cuppa/src/main/java/org/forgerock/cuppa/Configuration.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Configuration.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.forgerock.cuppa.model.TestBlock;
+import org.forgerock.cuppa.reporters.Reporter;
 
 /**
  * Holds configuration settings for Cuppa.
@@ -29,6 +30,7 @@ import org.forgerock.cuppa.model.TestBlock;
 public final class Configuration {
     List<Function<TestBlock, TestBlock>> testTransforms = new ArrayList<>();
     TestInstantiator testInstantiator = Class::newInstance;
+    Reporter additionalReporter;
 
     Configuration() {
     }
@@ -53,5 +55,15 @@ public final class Configuration {
     public void registerTestTreeTransform(Function<TestBlock, TestBlock> transform) {
         Objects.requireNonNull(transform, "Transform must not be null");
         testTransforms.add(transform);
+    }
+
+    /**
+     * Register a reporter that will be used in addition to the primary reporter given to the runner.
+     *
+     * @param reporter The reporter. Must not be null.
+     */
+    public void setAdditionalReporter(Reporter reporter) {
+        Objects.requireNonNull(reporter, "Reporter must not be null");
+        additionalReporter = reporter;
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -42,6 +42,7 @@ import org.forgerock.cuppa.model.Options;
 import org.forgerock.cuppa.model.Tags;
 import org.forgerock.cuppa.model.Test;
 import org.forgerock.cuppa.model.TestBlock;
+import org.forgerock.cuppa.reporters.CompositeReporter;
 import org.forgerock.cuppa.reporters.Reporter;
 
 /**
@@ -101,12 +102,15 @@ public final class Runner {
      * @param reporter The reporter to use to report test results.
      */
     public void run(TestBlock rootBlock, Reporter reporter) {
+        Reporter fullReporter = (configuration.additionalReporter != null)
+                ? new CompositeReporter(Arrays.asList(reporter, configuration.additionalReporter))
+                : reporter;
         TestContainer.INSTANCE.runTests(() -> {
-            reporter.start(rootBlock);
+            fullReporter.start(rootBlock);
             TestBlock transformedRootBlock = transformTests(rootBlock, configuration.testTransforms);
-            runTests(transformedRootBlock, Collections.emptyList(), transformedRootBlock.behaviour, reporter,
+            runTests(transformedRootBlock, Collections.emptyList(), transformedRootBlock.behaviour, fullReporter,
                     TestFunction::apply);
-            reporter.end();
+            fullReporter.end();
         });
     }
 


### PR DESCRIPTION
This allows users to specify a reporter when they cannot control how Cuppa is run, for example if they are using Surefire.