### PR TITLE
Remove requirement to pass at least one Option or Tag to Cuppa methods

### DIFF
--- a/cuppa/src/main/java/org/forgerock/cuppa/Cuppa.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Cuppa.java
@@ -173,7 +173,7 @@ public final class Cuppa {
 
     /**
      * Decorate a test or block of tests with additional options. Options are constructed via factory methods. For
-     * example, see {@link Cuppa#tags(String, String...)}.
+     * example, see {@link Cuppa#tags(String...)}.
      *
      * <p>Multiple options can be either passed as additional arguments or chained using the returned builder.</p>
      *
@@ -184,14 +184,13 @@ public final class Cuppa {
      * });
      * </code></pre>
      *
-     * @param option An option to apply to the test/block.
-     * @param options Additional options to apply to the test/block.
+     * @param options Options to apply to the test/block.
      * @return An object for building a test or test block with the given options.
      *
-     * @see Cuppa#tags(String, String...)
+     * @see Cuppa#tags(String...)
      */
-    public static TestBuilder with(Option<?> option, Option<?>... options) {
-        return TestContainer.INSTANCE.with(option, options);
+    public static TestBuilder with(Option<?>... options) {
+        return TestContainer.INSTANCE.with(options);
     }
 
     /**
@@ -233,7 +232,7 @@ public final class Cuppa {
      * test run.
      *
      * <p>Apply to a test or block of tests by passing the result of this method to
-     * {@link Cuppa#with(Option, Option...)}.</p>
+     * {@link Cuppa#with(Option...)}.</p>
      *
      * <pre><code>
      * with(tags("slow")).
@@ -242,13 +241,12 @@ public final class Cuppa {
      * });
      * </code></pre>
      *
-     * @param tag A string identifier that can be used when running Cuppa to include or exclude the test/block.
-     * @param tags Additional tags to apply to the test/block.
-     * @return An option, which can be passed to {@link Cuppa#with(Option, Option...)}.
+     * @param tags String identifiers that can be used when running Cuppa to include or exclude a test/block.
+     * @return An option, which can be passed to {@link Cuppa#with(Option...)}.
      *
-     * @see Cuppa#with(Option, Option...)
+     * @see Cuppa#with(Option...)
      */
-    public static Option tags(String tag, String... tags) {
-        return TestContainer.INSTANCE.tags(tag, tags);
+    public static Option tags(String... tags) {
+        return TestContainer.INSTANCE.tags(tags);
     }
 }

--- a/cuppa/src/main/java/org/forgerock/cuppa/TestBuilder.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/TestBuilder.java
@@ -39,7 +39,7 @@ public interface TestBuilder {
 
     /**
      * Decorate a test or block of tests with additional options. Options are constructed via factory methods. For
-     * example, see {@link Cuppa#tags(String, String...)}.
+     * example, see {@link Cuppa#tags(String...)}.
      *
      * <p>Multiple options can be either passed as additional arguments or chained using the returned builder.</p>
      *
@@ -50,13 +50,12 @@ public interface TestBuilder {
      * });
      * </code></pre>
      *
-     * @param option An option to apply to the test/block.
-     * @param options Additional options to apply to the test/block.
+     * @param options Options to apply to the test/block.
      * @return This, for chaining.
      *
-     * @see Cuppa#with(Option, Option...)
+     * @see Cuppa#with(Option...)
      */
-    TestBuilder with(Option<?> option, Option<?>... options);
+    TestBuilder with(Option<?>... options);
 
     /**
      * Mark a test or block of tests to be skipped.

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBuilderImpl.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBuilderImpl.java
@@ -33,8 +33,7 @@ final class TestBuilderImpl implements TestBuilder {
     private Behaviour behaviour = Behaviour.NORMAL;
 
     @Override
-    public TestBuilder with(Option<?> option, Option<?>... options) {
-        this.options.set(option);
+    public TestBuilder with(Option<?>... options) {
         for (Option<?> o : options) {
             this.options.set(o);
         }

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestContainer.java
@@ -219,13 +219,12 @@ public enum TestContainer {
     /**
      * Decorate a test or block of tests with additional options.
      *
-     * @param option An option to apply to the test/block.
-     * @param options Additional options to apply to the test/block.
+     * @param options Options to apply to the test/block.
      * @return An object for building a test or test block with the given options.
      */
-    public TestBuilder with(Option option, Option... options) {
+    public TestBuilder with(Option... options) {
         TestBuilderImpl testBuilder = new TestBuilderImpl();
-        return testBuilder.with(option, options);
+        return testBuilder.with(options);
     }
 
     /**
@@ -250,13 +249,11 @@ public enum TestContainer {
      * Decorates tests with a set of tags. Tags can be used to group tests together to be included or excluded from a
      * test run.
      *
-     * @param tag A string identifier that can be used when running Cuppa to include or exclude the test/block.
-     * @param tags Additional tags to apply to the test/block.
+     * @param tags String identifiers that can be used when running Cuppa to include or exclude a test/block.
      * @return An option.
      */
-    public Option tags(String tag, String... tags) {
+    public Option tags(String... tags) {
         Set<String> set = new HashSet<>();
-        set.add(tag);
         set.addAll(Arrays.asList(tags));
         return new TagsOption(set);
     }


### PR DESCRIPTION
This API design makes it difficult to call with() or tags() dynamically. I don't think there is much of a risk that users will use these APIs incorrectly.