### PR TITLE
Log class name of class if failed to be instantiated

### DIFF
--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -116,7 +116,7 @@ public final class Runner {
                     } catch (CuppaException e) {
                         throw e;
                     } catch (Exception e) {
-                        throw new IllegalStateException("Failed to instantiate test class", e);
+                        throw new IllegalStateException("Failed to instantiate test class: " + c.getName(), e);
                     }
                 }))
                 .reduce(EMPTY_TEST_BLOCK, this::mergeRootTestBlocks);


### PR DESCRIPTION
Currently if Cuppa fails to instantiate a test class it does not log the name of that class, only the fact that it failed to instantiate a test class. Logging the name of the test class would add in debugging issues.