### PR TITLE
Allow remove of Option from Options

### DIFF
--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBuilderImpl.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/TestBuilderImpl.java
@@ -29,13 +29,13 @@ import org.forgerock.cuppa.model.Option;
 import org.forgerock.cuppa.model.Options;
 
 final class TestBuilderImpl implements TestBuilder {
-    private final Options options = new Options();
+    private Options options = new Options();
     private Behaviour behaviour = Behaviour.NORMAL;
 
     @Override
     public TestBuilder with(Option<?>... options) {
         for (Option<?> o : options) {
-            this.options.set(o);
+            this.options = this.options.set(o);
         }
         return this;
     }

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Options.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Options.java
@@ -16,7 +16,6 @@
 
 package org.forgerock.cuppa.model;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -37,15 +36,6 @@ public final class Options {
 
     private Options(Map<Class<? extends Option>, Option<?>> options) {
         this.options = options;
-    }
-
-    /**
-     * Creates an immutable options set from the given options.
-     * @param options A set of options to copy.
-     * @return An immutable set of options.
-     */
-    public static Options immutableCopyOf(Options options) {
-        return new Options(Collections.unmodifiableMap(new HashMap<>(options.options)));
     }
 
     /**
@@ -79,10 +69,12 @@ public final class Options {
      *
      * @param option The option to store.
      * @param <T> The type of the option.
-     * @throws UnsupportedOperationException if this class is immutable.
+     * @return A new Option instance with the specified option.
      */
-    public <T> void set(Option<T> option) {
-        options.put(option.getClass(), option);
+    public <T> Options set(Option<T> option) {
+        Options copy = copyOf(this);
+        copy.options.put(option.getClass(), option);
+        return copy;
     }
 
     @Override

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Options.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Options.java
@@ -44,7 +44,7 @@ public final class Options {
      * @param options A set of options to copy.
      * @return An mutable set of options.
      */
-    public static Options copyOf(Options options) {
+    private static Options copyOf(Options options) {
         return new Options(new HashMap<>(options.options));
     }
 
@@ -62,6 +62,19 @@ public final class Options {
             return Optional.of(option.get());
         }
         return Optional.empty();
+    }
+
+    /**
+     * Removes an option.
+     *
+     * @param optionClass The class of the option to remove.
+     * @param <O> The type of the option.
+     * @return A new Option instance without the specified option.
+     */
+    public <O extends Option<?>> Options remove(Class<O> optionClass) {
+        Options copy = copyOf(this);
+        copy.options.remove(optionClass);
+        return copy;
     }
 
     /**

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Test.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Test.java
@@ -71,7 +71,7 @@ public final class Test {
         this.testClass = testClass;
         this.description = description;
         this.function = function;
-        this.options = Options.immutableCopyOf(options);
+        this.options = options;
     }
 
     @Override

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/TestBlock.java
@@ -97,7 +97,7 @@ public final class TestBlock {
         this.testBlocks = Collections.unmodifiableList(new ArrayList<>(testBlocks));
         this.hooks = Collections.unmodifiableList(new ArrayList<>(hooks));
         this.tests = Collections.unmodifiableList(new ArrayList<>(tests));
-        this.options = Options.immutableCopyOf(options);
+        this.options = options;
     }
 
     @Override

--- a/cuppa/src/test/java/org/forgerock/cuppa/ModelTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/ModelTests.java
@@ -50,8 +50,10 @@ public class ModelTests {
                 HookFunction.identity())))
                 .isExactlyInstanceOf(UnsupportedOperationException.class);
 
-        assertThatThrownBy(() -> testBlock.options.set(new TestOption("a")))
-                .isExactlyInstanceOf(UnsupportedOperationException.class);
+        Options options = testBlock.options;
+        testBlock.options.set(new TestOption("a"));
+        assertThat(testBlock.options).isEqualTo(options);
+        assertThat(testBlock.options.get(TestOption.class)).isEqualTo(Optional.empty());
     }
 
     @Test
@@ -81,8 +83,10 @@ public class ModelTests {
         org.forgerock.cuppa.model.Test test = new org.forgerock.cuppa.model.Test(NORMAL, ModelTests.class, "",
                 Optional.empty(), new Options());
 
-        assertThatThrownBy(() -> test.options.set(new TestOption("a")))
-                .isExactlyInstanceOf(UnsupportedOperationException.class);
+        Options options = test.options;
+        test.options.set(new TestOption("a"));
+        assertThat(test.options).isEqualTo(options);
+        assertThat(test.options.get(TestOption.class)).isEqualTo(Optional.empty());
     }
 
     @Test

--- a/cuppa/src/test/java/org/forgerock/cuppa/ModelTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/ModelTests.java
@@ -49,11 +49,6 @@ public class ModelTests {
         assertThatThrownBy(() -> testBlock.hooks.add(new Hook(HookType.BEFORE, ModelTests.class, Optional.empty(),
                 HookFunction.identity())))
                 .isExactlyInstanceOf(UnsupportedOperationException.class);
-
-        Options options = testBlock.options;
-        testBlock.options.set(new TestOption("a"));
-        assertThat(testBlock.options).isEqualTo(options);
-        assertThat(testBlock.options.get(TestOption.class)).isEqualTo(Optional.empty());
     }
 
     @Test
@@ -76,29 +71,6 @@ public class ModelTests {
         assertThat(testBlock.tests).hasSize(0);
         assertThat(testBlock.hooks).hasSize(0);
         assertThat(testBlock.options.get(TestOption.class)).isEmpty();
-    }
-
-    @Test
-    public void testShouldBeImmutable() {
-        org.forgerock.cuppa.model.Test test = new org.forgerock.cuppa.model.Test(NORMAL, ModelTests.class, "",
-                Optional.empty(), new Options());
-
-        Options options = test.options;
-        test.options.set(new TestOption("a"));
-        assertThat(test.options).isEqualTo(options);
-        assertThat(test.options.get(TestOption.class)).isEqualTo(Optional.empty());
-    }
-
-    @Test
-    public void testShouldTakeDefensiveCopiesOfMutableObjects() {
-        Options originalOptions = new Options();
-
-        org.forgerock.cuppa.model.Test test = new org.forgerock.cuppa.model.Test(NORMAL, ModelTests.class, "",
-                Optional.empty(), originalOptions);
-
-        originalOptions.set(new TestOption("a"));
-
-        assertThat(test.options.get(TestOption.class)).isEmpty();
     }
 
     private static final class TestOption extends Option<String> {

--- a/cuppa/src/test/java/org/forgerock/cuppa/OptionsTest.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/OptionsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.forgerock.cuppa.model.Option;
+import org.forgerock.cuppa.model.Options;
+import org.testng.annotations.Test;
+
+public class OptionsTest {
+
+    @Test
+    public void addingNewOptionShouldReturnNewOptionCopy() {
+        Options options = new Options();
+        Options optionsCopy = options.set(new TestOption());
+        assertThat(options.get(TestOption.class)).isEqualTo(Optional.empty());
+        assertThat(optionsCopy.get(TestOption.class)).isNotEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void removingOptionShouldReturnNewOptionCopy() {
+        Options options = new Options().set(new TestOption());
+        Options optionsCopy = options.remove(TestOption.class);
+        assertThat(options.get(TestOption.class)).isNotEqualTo(Optional.empty());
+        assertThat(optionsCopy.get(TestOption.class)).isEqualTo(Optional.empty());
+    }
+
+    private static final class TestOption extends Option<String> {
+        private TestOption() {
+            super("a");
+        }
+    }
+}


### PR DESCRIPTION
We offer the ability to manipulate `Options` by adding new `Option`s to it but offer no ability to remove `Option`s from it. This change will allow this without modifying the `Options` by returning a copy of it with the specified `Option` removed.

When adding new `Option`s I noticed we modify the same `Options` instance, should that be an immutable operation?