### PR TITLE
Add support for intersection groups

### DIFF
--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -33,6 +33,7 @@ import org.forgerock.cuppa.internal.TestContainer;
 import org.forgerock.cuppa.internal.filters.EmptyTestBlockFilter;
 import org.forgerock.cuppa.internal.filters.OnlyTestBlockFilter;
 import org.forgerock.cuppa.internal.filters.TagTestBlockFilter;
+import org.forgerock.cuppa.internal.filters.expression.ExpressionTagTestBlockFilter;
 import org.forgerock.cuppa.model.Tags;
 import org.forgerock.cuppa.model.TestBlock;
 import org.forgerock.cuppa.model.TestBlockBuilder;
@@ -77,8 +78,8 @@ public final class Runner {
      * @param configuration Cuppa configuration to control the behaviour of the runner.
      */
     public Runner(Tags runTags, Configuration configuration) {
-        coreTestTransforms = Arrays.asList(new OnlyTestBlockFilter(), new TagTestBlockFilter(runTags),
-                new EmptyTestBlockFilter());
+        coreTestTransforms = Arrays.asList(new OnlyTestBlockFilter(), new ExpressionTagTestBlockFilter(runTags),
+                new TagTestBlockFilter(runTags), new EmptyTestBlockFilter());
         this.configuration = configuration;
     }
 

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/AndCondition.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/AndCondition.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A condition that composes other conditions with a logical AND.
+ */
+class AndCondition extends ConditionWrapper {
+
+    public static final AndCondition EMPTY = new AndCondition(Collections.emptyList());
+    private final Collection<Condition> conditions;
+
+    /**
+     * Constructor.
+     *
+     * @param conditions a list of condition to compose.
+     */
+    AndCondition(Collection<Condition> conditions) {
+        this.conditions = Collections.unmodifiableCollection(conditions);
+    }
+
+    @Override
+    public boolean shouldRun(Collection<String> tags) {
+        return conditions.stream().allMatch(c -> c.shouldRun(tags));
+    }
+
+    @Override
+    public ConditionWrapper setConditions(Collection<Condition> conditions) {
+        return new AndCondition(conditions);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/Condition.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/Condition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 ForgeRock AS.
+ * Copyright 2018 ForgeRock AS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,22 @@
  * limitations under the License.
  */
 
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Collection;
+
 /**
- * A testing framework for Java 8.
+ * A condition used by {@link ExpressionTagTestBlockFilter}.
  */
-package org.forgerock.cuppa;
+@FunctionalInterface
+public interface Condition {
+
+    /**
+     * Check if the list of tags is compliant with the condition.
+     *
+     * @param tags The collection of tags.
+     * @return true if the condition complies with the tags supplied, false otherwise.
+     */
+    boolean shouldRun(Collection<String> tags);
+
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ConditionFactory.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ConditionFactory.java
@@ -1,0 +1,58 @@
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A factory to creates {@link ConditionWrapper}.
+ */
+final class ConditionFactory {
+
+    /**
+     * link the operator to an instance of {@link Condition}.
+     */
+    enum ConditionEnum {
+        AND("and", AndCondition.EMPTY),
+        OR("or", OrCondition.EMPTY),
+        NOT("not", NotCondition.EMPTY);
+
+        private String operator;
+        private ConditionWrapper condition;
+
+        ConditionEnum(String operator, ConditionWrapper condition) {
+            this.operator = operator;
+            this.condition = condition;
+        }
+
+        /**
+         * Get a ConditionEnum fron an string operator.
+         * @param operator The operator we want to get the associated enum
+         * @return The ConditionEnum
+         */
+        static ConditionEnum getFromOperator(String operator) {
+            return Arrays.stream(ConditionEnum.values())
+                    .filter(c -> c.operator.equals(operator))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(operator + " is not supported. The list of "
+                            + "supported operator is and, or, not"));
+        }
+
+        Condition getCondition(List<Condition> tags) {
+            return condition.setConditions(tags);
+        }
+    }
+
+    private ConditionFactory() {
+    }
+
+    /**
+     * Create a {@link Condition}.
+     * @param operator The operator we want to create a condition for.
+     * @param tags The list of conditions that {@link ConditionWrapper} will include.
+     * @return A condition
+     */
+    static Condition get(String operator, List<Condition> tags) {
+        return ConditionEnum.getFromOperator(operator.trim().toLowerCase())
+                .getCondition(tags);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ConditionWrapper.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ConditionWrapper.java
@@ -1,0 +1,16 @@
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Collection;
+
+/**
+ * A condition wrapper for Condition that needs to wrap other conditions.
+ */
+abstract class ConditionWrapper implements Condition {
+
+    /**
+     * Create a new Condition with the given conditions.
+     * @param conditions the collection of conditions
+     * @return a new condition
+     */
+    abstract ConditionWrapper setConditions(Collection<Condition> conditions);
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ContainsCondition.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ContainsCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 ForgeRock AS.
+ * Copyright 2018 ForgeRock AS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,28 @@
  * limitations under the License.
  */
 
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Collection;
+
 /**
- * A testing framework for Java 8.
+ * A condition that checks if a tag is contains in a collection of tags.
  */
-package org.forgerock.cuppa;
+class ContainsCondition implements Condition {
+
+    private String tag;
+
+    /**
+     * Constructor.
+     *
+     * @param tag A group/tag we want to search for.
+     */
+    ContainsCondition(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public boolean shouldRun(Collection<String> tags) {
+        return tags.contains(tag);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ExpressionParser.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ExpressionParser.java
@@ -1,0 +1,95 @@
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * This class is responsible to parse an expression tag to a {@link Condition} .
+ */
+final class ExpressionParser {
+
+    private ExpressionParser() {
+    }
+
+    /**
+     * Parse the expressionTags to a Condition.
+     * @param expressionTags the expression to parse
+     * @return The condition
+     */
+    static Condition parse(String expressionTags) {
+        if (expressionTags.isEmpty()) {
+            return (t) -> true;
+        }
+
+        Stack<String> operators = new Stack<>();
+        Stack<Integer> numberOfGroupsPerOperator = new Stack<>();
+        Stack<Condition> groups = new Stack<>();
+
+        String currentWord = "";
+        char[] chars = expressionTags.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i];
+            switch (c) {
+                case '(':
+                    pushOperator(expressionTags, operators, numberOfGroupsPerOperator, currentWord, i);
+                    currentWord = "";
+                    break;
+                case ',':
+                case ';':
+                    addEqualCondition(groups, currentWord, numberOfGroupsPerOperator);
+                    currentWord = "";
+                    break;
+                case ')':
+                    pushComplexCondition(operators, numberOfGroupsPerOperator, groups, currentWord);
+                    currentWord = "";
+                    break;
+                default:
+                    currentWord += c;
+                    break;
+            }
+        }
+
+        if (groups.size() != 1 || numberOfGroupsPerOperator.size() != 0 || operators.size() != 0) {
+            throw new IllegalArgumentException("malformed expression " + expressionTags);
+        }
+
+        return groups.pop();
+    }
+
+    private static void pushComplexCondition(Stack<String> operators, Stack<Integer> numberOfGroupsPerOperator,
+            Stack<Condition> groups, String currentWord) {
+        addEqualCondition(groups, currentWord, numberOfGroupsPerOperator);
+
+        String operator = operators.pop();
+        int number = numberOfGroupsPerOperator.pop();
+        List<Condition> tags = new ArrayList<>(number);
+
+        for (; number > 0; number--) {
+            tags.add(groups.pop());
+        }
+
+        groups.push(ConditionFactory.get(operator, tags));
+        if (!numberOfGroupsPerOperator.isEmpty()) {
+            numberOfGroupsPerOperator.push(numberOfGroupsPerOperator.pop() + 1);
+        }
+    }
+
+    private static void pushOperator(String expressionTags, Stack<String> operators,
+            Stack<Integer> numberOfGroupsPerOperator, String currentWord, int i) {
+        if ("".equals(currentWord)) {
+            throw new IllegalArgumentException("malformed expression ( " + expressionTags + " ). "
+                    + "An operator was expected column " + i);
+        }
+        operators.push(currentWord);
+        numberOfGroupsPerOperator.push(0);
+    }
+
+    private static void addEqualCondition(Stack<Condition> groups, String currentWord, Stack<Integer> numbers) {
+        String trimmedWord = currentWord.trim();
+        if (!"".equals(trimmedWord)) {
+            groups.push(new ContainsCondition(trimmedWord));
+            numbers.push(numbers.pop() + 1);
+        }
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ExpressionTagTestBlockFilter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/ExpressionTagTestBlockFilter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.forgerock.cuppa.model.Options;
+import org.forgerock.cuppa.model.Tags;
+import org.forgerock.cuppa.model.TagsOption;
+import org.forgerock.cuppa.model.Test;
+import org.forgerock.cuppa.model.TestBlock;
+
+
+/**
+ * Filter the tests according to the expression tag.
+ * It uses a set of conditions to decide if it should run a test.
+ *
+ * @see Condition
+ */
+public final class ExpressionTagTestBlockFilter implements Function<TestBlock, TestBlock> {
+    private final Tags runTags;
+    private final Condition condition;
+
+    /**
+     * Creates a new filter.
+     *
+     * @param runTags runTags
+     */
+    public ExpressionTagTestBlockFilter(Tags runTags) {
+        this.runTags = runTags;
+        this.condition = ExpressionParser.parse(runTags.expressionTags);
+    }
+
+    @Override
+    public TestBlock apply(TestBlock testBlock) {
+        if (runTags.expressionTags.isEmpty()) {
+            return testBlock;
+        }
+
+        return filterTests(testBlock, Collections.emptySet());
+    }
+
+    private TestBlock filterTests(TestBlock testBlock, Set<String> parentBlockTags) {
+        Set<String> blockTags = union(getTags(testBlock.options), parentBlockTags);
+        List<TestBlock> testBlocks = testBlock.testBlocks.stream()
+                .map(b -> filterTests(b, blockTags))
+                .collect(Collectors.toList());
+        List<Test> tests = testBlock.tests.stream()
+                .filter(t -> condition.shouldRun(union(getTags(t.options), blockTags)))
+                .collect(Collectors.toList());
+        return testBlock.toBuilder()
+                .setTestBlocks(testBlocks)
+                .setTests(tests)
+                .build();
+    }
+
+    private Set<String> getTags(Options options) {
+        return options.get(TagsOption.class).orElse(Collections.emptySet());
+    }
+
+    private <T> Set<T> union(Set<T> a, Set<T> b) {
+        Set<T> union = new HashSet<>(a);
+        union.addAll(b);
+        return union;
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/NotCondition.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/NotCondition.java
@@ -1,0 +1,37 @@
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * A wrapper condition that inverse the wrapped condition.
+ */
+class NotCondition extends ConditionWrapper {
+
+    public static final NotCondition EMPTY = new NotCondition(Collections.emptyList());
+    private final Optional<Condition> condition;
+
+    /**
+     * Constructor.
+     *
+     * @param conditions a singletonList of condition.
+     */
+    NotCondition(Collection<Condition> conditions) {
+        if (conditions.size() > 1) {
+            throw new IllegalArgumentException(NotCondition.class + " cannot have more than one tag");
+        }
+        this.condition = conditions.stream().findFirst();
+    }
+
+    @Override
+    public boolean shouldRun(Collection<String> tags) {
+        return !condition.orElse(c -> true).shouldRun(tags);
+    }
+
+    @Override
+    public ConditionWrapper setConditions(Collection<Condition> conditions) {
+        return new NotCondition(conditions);
+    }
+}
+

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/OrCondition.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/OrCondition.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.forgerock.cuppa.internal.filters.expression;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A condition that composes other conditions with a logical OR.
+ */
+class OrCondition extends ConditionWrapper {
+
+    public static final OrCondition EMPTY = new OrCondition(Collections.emptyList());
+    private final Collection<Condition> conditions;
+
+    /**
+     * Constructor.
+     *
+     * @param conditions a list of condition to compose.
+     */
+    OrCondition(Collection<Condition> conditions) {
+        this.conditions = Collections.unmodifiableCollection(conditions);
+    }
+
+    @Override
+    public boolean shouldRun(Collection<String> tags) {
+        return conditions.stream().anyMatch(c -> c.shouldRun(tags));
+    }
+
+    @Override
+    public ConditionWrapper setConditions(Collection<Condition> conditions) {
+        return new OrCondition(conditions);
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/package-info.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/filters/expression/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 ForgeRock AS.
+ * Copyright 2018 ForgeRock AS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,6 @@
  */
 
 /**
- * A testing framework for Java 8.
+ * Classes related to the expression group filter.
  */
-package org.forgerock.cuppa;
+package org.forgerock.cuppa.internal.filters.expression;

--- a/cuppa/src/main/java/org/forgerock/cuppa/internal/package-info.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 ForgeRock AS.
+ * Copyright 2015-2018 ForgeRock AS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cuppa/src/main/java/org/forgerock/cuppa/model/Tags.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/model/Tags.java
@@ -16,7 +16,8 @@
 
 package org.forgerock.cuppa.model;
 
-import java.util.Collections;
+import static java.util.Collections.emptySet;
+
 import java.util.Set;
 
 /**
@@ -27,7 +28,7 @@ public class Tags {
     /**
      * No tags specified, meaning no tests should be filtered from the test run.
      */
-    public static final Tags EMPTY_TAGS = new Tags(Collections.emptySet(), Collections.emptySet());
+    public static final Tags EMPTY_TAGS = new Tags(emptySet(), emptySet(), "");
 
     /**
      * The set of tags which tests must be tagged with to be included in the test run.
@@ -40,14 +41,22 @@ public class Tags {
     public final Set<String> excludedTags;
 
     /**
+     * An expression of tags using condition to create complex tag filtering.
+     */
+    public final String expressionTags;
+
+    /**
      * Constructs a {@code Tags} instance with the specified tags and anti-tags (excluded tags).
      *
      * @param tags The set of tags which tests must be tagged with to be included in the test run.
      * @param excludedTags The set of excluded tags which tests must not be tagged with to be included
      *     in the test run.
+     * @param expressionTags An expression using condition to create complex tag filtering
+     * {@link org.forgerock.cuppa.internal.filters.expression.Condition}
      */
-    public Tags(Set<String> tags, Set<String> excludedTags) {
+    public Tags(Set<String> tags, Set<String> excludedTags, String expressionTags) {
         this.tags = tags;
+        this.expressionTags = expressionTags;
         this.excludedTags = excludedTags;
     }
 
@@ -58,7 +67,7 @@ public class Tags {
      * @return The {@code Tags} instance.
      */
     public static Tags tags(Set<String> tags) {
-        return new Tags(tags, Collections.emptySet());
+        return new Tags(tags, emptySet(), "");
     }
 
     /**
@@ -69,6 +78,16 @@ public class Tags {
      * @return The {@code Tags} instance.
      */
     public static Tags excludedTags(Set<String> excludedTags) {
-        return new Tags(Collections.emptySet(), excludedTags);
+        return new Tags(emptySet(), excludedTags, "");
+    }
+
+    /**
+     * Constructs a {@code Tags} instance with the specified expression tag.
+     *
+     * @param expressionTag The expression tag
+     * @return The {@code Tags} instance.
+     */
+    public static Tags expressionTags(String expressionTag) {
+        return new Tags(emptySet(), emptySet(), expressionTag);
     }
 }

--- a/cuppa/src/test/java/org/forgerock/cuppa/TaggedTests.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/TaggedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ForgeRock AS.
+ * Copyright 2018 ForgeRock AS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,18 @@
 
 package org.forgerock.cuppa;
 
-import static org.forgerock.cuppa.Cuppa.*;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+import static org.forgerock.cuppa.Cuppa.tags;
+import static org.forgerock.cuppa.Cuppa.with;
 import static org.forgerock.cuppa.TestCuppaSupport.defineTests;
 import static org.forgerock.cuppa.TestCuppaSupport.runTests;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -374,7 +381,7 @@ public class TaggedTests {
         });
 
         //When
-        runTests(rootBlock, reporter, new Tags(tags, excludedTags));
+        runTests(rootBlock, reporter, new Tags(tags, excludedTags, ""));
 
         //Then
         verify(testFunction, never()).apply();
@@ -401,7 +408,7 @@ public class TaggedTests {
         });
 
         //When
-        runTests(rootBlock, reporter, new Tags(tags, excludedTags));
+        runTests(rootBlock, reporter, new Tags(tags, excludedTags, ""));
 
         //Then
         verify(testFunctionNotRun, never()).apply();

--- a/cuppa/src/test/java/org/forgerock/cuppa/internal/filters/expression/ExpressionTagTestBlockFilterTest.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/internal/filters/expression/ExpressionTagTestBlockFilterTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2018 ForgeRock AS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.forgerock.cuppa.internal.filters.expression;
+
+import static java.util.Collections.emptySet;
+import static org.forgerock.cuppa.model.TestBlockType.ROOT;
+import static org.forgerock.cuppa.model.TestBlockType.WHEN;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.forgerock.cuppa.model.Options;
+import org.forgerock.cuppa.model.Tags;
+import org.forgerock.cuppa.model.TagsOption;
+import org.forgerock.cuppa.model.Test;
+import org.forgerock.cuppa.model.TestBlock;
+import org.forgerock.cuppa.model.TestBlockBuilder;
+import org.forgerock.cuppa.model.TestBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+
+
+/**
+ * Tests the {@link ExpressionTagTestBlockFilter} class.
+ */
+public class ExpressionTagTestBlockFilterTest {
+
+    private TestBlock root;
+
+    @BeforeTest
+    public void before() {
+        TestBlock child = new TestBlockBuilder()
+                .setType(WHEN)
+                .setTestClass(ExpressionTagTestBlockFilterTest.class)
+                .setTests(getTests("child-tag "))
+                .setDescription("child description")
+                .setOptions(createOption("child-tag"))
+                .build();
+        root = new TestBlockBuilder()
+                .setType(ROOT)
+                .setTestClass(ExpressionTagTestBlockFilterTest.class)
+                .setTests(getTests(""))
+                .setDescription("root description")
+                .setTestBlocks(Collections.singletonList(child)).build();
+    }
+
+    private static List<Test> getTests(String tags) {
+        List<Test> tests = new ArrayList<>();
+        tests.add(buildNormalTest(tags + "other", createOption("other")));
+        tests.add(buildNormalTest(tags + "ui", createOption("ui")));
+        tests.add(buildNormalTest(tags + "ui other", createOption("ui", "other")));
+        tests.add(buildNormalTest(tags + "smoke", createOption("smoke")));
+        tests.add(buildNormalTest(tags + "smoke other", createOption("smoke", "other")));
+        return tests;
+    }
+
+    private static Test buildNormalTest(String description, Options options) {
+        return new TestBuilder()
+                .setDescription(description)
+                .setFunction(Optional.empty())
+                .setTestClass(ExpressionTagTestBlockFilterTest.class)
+                .setOptions(options).build();
+    }
+
+    @org.testng.annotations.Test
+    public void noTagsReturnAll() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(), ""));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 10);
+    }
+
+    @org.testng.annotations.Test
+    public void emptyIntersectionOf2GroupsIsEmpty() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "and(ui,smoke)"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertTrue(testsDescription.isEmpty());
+    }
+
+
+    @org.testng.annotations.Test
+    public void intersectionOf2GroupsSuccess() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "and(child-tag,smoke)"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 2);
+        Assert.assertTrue(testsDescription.contains("child-tag smoke"));
+        Assert.assertTrue(testsDescription.contains("child-tag smoke other"));
+    }
+
+    @org.testng.annotations.Test
+    public void intersectionOf2GroupsWithNOTSuccess() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "not(and(child-tag,smoke))"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 8);
+        Assert.assertTrue(testsDescription.contains("child-tag ui"));
+        Assert.assertTrue(testsDescription.contains("ui"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui other"));
+        Assert.assertTrue(testsDescription.contains("ui other"));
+        Assert.assertTrue(testsDescription.contains("smoke other"));
+        Assert.assertTrue(testsDescription.contains("other"));
+        Assert.assertTrue(testsDescription.contains("smoke"));
+        Assert.assertTrue(testsDescription.contains("child-tag other"));
+    }
+
+    @org.testng.annotations.Test
+    public void notAGroupSuccess() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "not(smoke)"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 6);
+        Assert.assertTrue(testsDescription.contains("child-tag ui"));
+        Assert.assertTrue(testsDescription.contains("ui"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui other"));
+        Assert.assertTrue(testsDescription.contains("ui other"));
+        Assert.assertTrue(testsDescription.contains("other"));
+        Assert.assertTrue(testsDescription.contains("child-tag other"));
+    }
+
+    @org.testng.annotations.Test
+    public void intersectionOf2GroupsWithOperatorUppercaseSuccess() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "AND(child-tag,smoke)"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 2);
+        Assert.assertTrue(testsDescription.contains("child-tag smoke"));
+        Assert.assertTrue(testsDescription.contains("child-tag smoke other"));
+    }
+
+    @org.testng.annotations.Test
+    public void intersectionOf3GroupsSuccess() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "and(child-tag,smoke,other)"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 1);
+        Assert.assertTrue(testsDescription.contains("child-tag smoke other"));
+    }
+
+    @org.testng.annotations.Test
+    public void intersectionOf2GroupsAndIncludeOf1Success() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "or(ui,and(child-tag,smoke))"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 6);
+        Assert.assertTrue(testsDescription.contains("child-tag smoke"));
+        Assert.assertTrue(testsDescription.contains("child-tag smoke other"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui"));
+        Assert.assertTrue(testsDescription.contains("ui"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui other"));
+        Assert.assertTrue(testsDescription.contains("ui other"));
+    }
+
+    @org.testng.annotations.Test
+    public void intersectionOf3GroupsAndIncludeOf1Success() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "or(ui,and(child-tag,smoke,other))"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 5);
+        Assert.assertTrue(testsDescription.contains("child-tag smoke other"));
+        Assert.assertTrue(testsDescription.contains("ui"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui"));
+        Assert.assertTrue(testsDescription.contains("ui other"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui other"));
+    }
+
+    @org.testng.annotations.Test
+    public void intersectionOf2GroupsAnd2IncludeOf1Success() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "or(ui,and(child-tag,smoke),other)"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 9);
+        Assert.assertTrue(testsDescription.contains("child-tag smoke"));
+        Assert.assertTrue(testsDescription.contains("child-tag smoke other"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui"));
+        Assert.assertTrue(testsDescription.contains("ui"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui other"));
+        Assert.assertTrue(testsDescription.contains("ui other"));
+        Assert.assertTrue(testsDescription.contains("smoke other"));
+        Assert.assertTrue(testsDescription.contains("other"));
+        Assert.assertTrue(testsDescription.contains("child-tag other"));
+    }
+
+    @org.testng.annotations.Test
+    public void intersectionOf2GroupsAnd2IncludeOf1WithSpacesSuccess() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "or(ui , and ( child-tag,  smoke),other  )"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 9);
+        Assert.assertTrue(testsDescription.contains("child-tag smoke"));
+        Assert.assertTrue(testsDescription.contains("child-tag smoke other"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui"));
+        Assert.assertTrue(testsDescription.contains("ui"));
+        Assert.assertTrue(testsDescription.contains("child-tag ui other"));
+        Assert.assertTrue(testsDescription.contains("ui other"));
+        Assert.assertTrue(testsDescription.contains("smoke other"));
+        Assert.assertTrue(testsDescription.contains("other"));
+        Assert.assertTrue(testsDescription.contains("child-tag other"));
+    }
+
+    @org.testng.annotations.Test(expectedExceptions = IllegalArgumentException.class)
+    public void missingRightParenthesisThrowException() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "or(ui,and(child-tag,smoke),other"));
+        filter.apply(root);
+    }
+
+    @org.testng.annotations.Test(expectedExceptions = IllegalArgumentException.class)
+    public void missingOperatorThrowException() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "or(ui,(child-tag,smoke),other)"));
+        filter.apply(root);
+    }
+
+    @org.testng.annotations.Test(expectedExceptions = IllegalArgumentException.class)
+    public void unknownOperatorThrowException() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "unknown(ui,(child-tag,smoke),other)"));
+        filter.apply(root);
+    }
+
+    @org.testng.annotations.Test(expectedExceptions = IllegalArgumentException.class)
+    public void notSingleRootThowAnException() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "or(ui),and(other)"));
+        filter.apply(root);
+    }
+
+    @org.testng.annotations.Test
+    public void emptyGroupisValid() throws Exception {
+        ExpressionTagTestBlockFilter filter = new ExpressionTagTestBlockFilter(new Tags(emptySet(), emptySet(),
+                "and()"));
+        TestBlock testBlocks = filter.apply(root);
+
+        List<String> testsDescription = getTestsDescription(testBlocks);
+        Assert.assertEquals(testsDescription.size(), 10);
+    }
+
+    private List<String> getTestsDescription(TestBlock testBlock) {
+        Set<String> subTestsDescription = testBlock.testBlocks.stream()
+                .flatMap(tb -> getTestsDescription(tb).stream())
+                .collect(Collectors.toSet());
+
+        Set<String> description = testBlock.tests.stream().map(t -> t.description).collect(Collectors.toSet());
+
+        return union(subTestsDescription, description);
+    }
+
+    private static Options createOption(String... tags) {
+        return Options.EMPTY.set(new TagsOption(new HashSet<>(Arrays.asList(tags))));
+    }
+
+    private <T> List<T> union(Collection<T> list1, Collection<T> list2) {
+        Set<T> set = new HashSet<>();
+
+        set.addAll(list1);
+        set.addAll(list2);
+
+        return new ArrayList<>(set);
+    }
+}

--- a/docs/_docs/tagging-tests.md
+++ b/docs/_docs/tagging-tests.md
@@ -35,14 +35,28 @@ For example, to run all tests except tests tagged with `slow`:
 mvn -DexcludedTags=slow test
 ```
 
+If you want more flexibility you can use an expression.
+For example, to run all the tests with `fast` tag or with `smoke` and `ui` tags excluding all `slow` tags :
+
+```bash
+mvn -DgroupsExpression="and(or(fast,and(smoke,ui)),not(slow))"
+```
+
 <div class="alert alert-info" role="alert">
 #### Note
 
 When running with a combination of TestNG or JUnit along side Cuppa, you can use the TestNG/JUnit way of 
 specifying/excluding groups so that you can run a sub-set of tests across both TestNG/JUnit and Cuppa.
 
-It's important to note that you cannot use both `-Dgroups=` and `-Dtags=` or `-DexcludedGroups=` and `-DexcludedTags=` 
-at the same time.
+It's important to note that you cannot use `-Dgroups=` and `-Dtags=`, `-DexcludedGroups=` and `-DexcludedTags=` 
+or `-DgroupsExpression` and `-DtagsExpression` at the same time.
+</div>
+
+<div class="alert alert-info" role="alert">
+#### Note 2
+
+It's important to note that you cannot if you use the expression you cannot use tags/groups or 
+excludedTags/excludedGroups
 </div>
 
 ## Tagging a Block of Tests


### PR DESCRIPTION
This feature modifies the `TagTestBlockFilter` to handle the intersection groups. It also modifies the `ConfigurationProvider` to pass the plugin properties as a parameter.

That intersection group could have been added as a custom testTransforms from the configuration of my own project but it was a bit hacky because the current `TagTestBlockFilter` would have been applied to the test blocks after my own filter. Plus, in the transformer, it wasn't possible to get the properties defined in the surefire plugin.

I ended up creating that PR because I think other cuppa users could benefit it.

Example : 
`mvn verify -Dgroups=smoke -DintersectGroups=group1,group2`
Will return all the smoke tests plus the intersection of group1 and group2

Signed-off-by: Alex ROBUCHON <alex.robuchon@forgerock.com>