### PR TITLE
Fix duplicate key signature & Release Cuppa 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,6 @@ subprojects {
   }
 
   artifacts {
-    archives jar
     archives javadocJar
     archives sourcesJar
   }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ allprojects {
   apply plugin: 'jacoco'
 
   group = 'org.forgerock.cuppa'
-  version = '1.4.0'
+  version = '1.5.0'
 
   repositories {
     mavenLocal()

--- a/docs/_posts/2019-09-30-1.5.0-released.md
+++ b/docs/_posts/2019-09-30-1.5.0-released.md
@@ -1,0 +1,14 @@
+---
+title: 1.5.0 Released
+author: phillcunnington
+---
+
+**Cuppa 1.5.0 is now available.**
+
+This release exposes the run parameters for which groups/tags to run to the `ConfigurationProvider` via `Configuration#getRunOptions()` and `Runner.TagRunOption` option type. To enable working with the now-visible groups expressions, the `expression` package and classes are now public and supported.
+
+With this extra information, it is possible to apply tags in different ways to the out-of-the-box behaviour, and so an additional method is added to remove the default test transforms, `Configuration#removeCoreTestTransforms()`.
+
+Finally, the two existing `Runner` constructors have been deprecated, and constructors that use the new `Options` to provide tag configuration are added.
+
+Check out [the release](https://github.com/cuppa-framework/cuppa/releases/tag/v1.5.0).


### PR DESCRIPTION
Fixes issue when trying to build and sign and updates version to 1.5.0