### PR TITLE
Add ability to determine test run end status (#137)

### DIFF
--- a/cuppa/src/main/java/org/forgerock/cuppa/ExitCodeReporter.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/ExitCodeReporter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 ForgeRock AS. All Rights Reserved
+ *
+ * Use of this code requires a commercial software license with ForgeRock AS.
+ * or with one of its affiliates. All use shall be exclusively subject
+ * to such license between the licensee and ForgeRock AS.
+ */
+package org.forgerock.cuppa;
+
+import java.util.List;
+
+import org.forgerock.cuppa.model.Hook;
+import org.forgerock.cuppa.model.Test;
+import org.forgerock.cuppa.model.TestBlock;
+import org.forgerock.cuppa.reporters.Reporter;
+
+/**
+ * Reporter that tracks the outcome of hooks and tests to determine what the overall status of the test run
+ * is.
+ *
+ * <p>The following list specifies the order in which the exit code is determined:
+ * <ol>
+ *     <li>If no tests are run the exit code will be {@literal 4}.</li>
+ *     <li>If any block, test hook or test fails the exit code will be {@literal 1}.</li>
+ *     <li>If any test is skipped the exit code will be {@literal 2}.</li>
+ *     <li>If any test is pending the exit code will be {@literal 3}.</li>
+ *     <li>If none of the above the exit code will be {@literal 0}.</li>
+ * </ol>
+ *
+ * <p>Exit codes {@literal 0}, {@literal 2} and {@literal 3} could be seen as a successful run depending on
+ * the configuration of the test run (i.e. transforms executed), this determination is up to the caller to
+ * decide.
+ */
+public final class ExitCodeReporter implements Reporter {
+
+    private static final int SUCCESS = 0;
+    private static final int FAILED_TESTS = 1;
+    private static final int SKIPPED_TESTS = 2;
+    private static final int PENDING_TESTS = 3;
+    private static final int NO_TESTS = 4;
+
+    private boolean testsRun;
+    private boolean failedTests;
+    private boolean skippedTests;
+    private boolean pendingTests;
+
+    ExitCodeReporter() {
+    }
+
+    /**
+     * Determines the exit code based on the results of the test run.
+     *
+     * @return The exit code.
+     */
+    int getExitCode() {
+        int exitCode = SUCCESS;
+        if (!testsRun) {
+            exitCode = NO_TESTS;
+        } else if (failedTests) {
+            exitCode = FAILED_TESTS;
+        } else if (skippedTests) {
+            exitCode = SKIPPED_TESTS;
+        } else if (pendingTests) {
+            exitCode = PENDING_TESTS;
+        }
+        return exitCode;
+    }
+
+    @Override
+    public void testHookFail(Hook hook, List<TestBlock> hookParents, Test test, List<TestBlock> testParents,
+            Throwable cause) {
+        failedTests = true;
+    }
+
+    @Override
+    public void blockHookFail(Hook hook, List<TestBlock> parents, Throwable cause) {
+        failedTests = true;
+    }
+
+    @Override
+    public void testStart(Test test, List<TestBlock> parents) {
+        testsRun = true;
+    }
+
+    @Override
+    public void testFail(Test test, List<TestBlock> parents, Throwable cause) {
+        failedTests = true;
+    }
+
+    @Override
+    public void testPending(Test test, List<TestBlock> parents) {
+        pendingTests = true;
+    }
+
+    @Override
+    public void testSkip(Test test, List<TestBlock> parents) {
+        skippedTests = true;
+    }
+}

--- a/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
+++ b/cuppa/src/main/java/org/forgerock/cuppa/Runner.java
@@ -57,6 +57,7 @@ public final class Runner {
             Arrays.asList(new OnlyTestBlockFilter(), new EmptyTestBlockFilter());
 
     private final Configuration configuration;
+    private final ExitCodeReporter exitCodeReporter = new ExitCodeReporter();
 
     /**
      * Creates a new runner with no run tags and a configuration loaded from the classpath.
@@ -141,8 +142,8 @@ public final class Runner {
      */
     public void run(TestBlock rootBlock, Reporter reporter) {
         Reporter fullReporter = (configuration.additionalReporter != null)
-                ? new CompositeReporter(Arrays.asList(reporter, configuration.additionalReporter))
-                : reporter;
+                ? new CompositeReporter(Arrays.asList(exitCodeReporter, reporter, configuration.additionalReporter))
+                : new CompositeReporter(Arrays.asList(exitCodeReporter, reporter));
         TestContainer.INSTANCE.runTests(() -> {
             fullReporter.start(rootBlock);
             TestBlock transformedRootBlock = transformTests(rootBlock,
@@ -150,6 +151,16 @@ public final class Runner {
             runTests(transformedRootBlock, fullReporter);
             fullReporter.end();
         });
+    }
+
+    /**
+     * Returns the final status of the test run as an exit code.
+     * See {@link ExitCodeReporter} for details on the possible exit codes and their meanings.
+     *
+     * @return The exit code of the test run.
+     */
+    public int getExitCode() {
+        return exitCodeReporter.getExitCode();
     }
 
     private TestBlock defineTestsWithConfiguration(Iterable<Class<?>> testClasses, TestInstantiator testInstantiator) {

--- a/cuppa/src/test/java/org/forgerock/cuppa/ExitCodeReporterTest.java
+++ b/cuppa/src/test/java/org/forgerock/cuppa/ExitCodeReporterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 ForgeRock AS. All Rights Reserved
+ *
+ * Use of this code requires a commercial software license with ForgeRock AS.
+ * or with one of its affiliates. All use shall be exclusively subject
+ * to such license between the licensee and ForgeRock AS.
+ */
+package org.forgerock.cuppa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.annotations.Test;
+
+public class ExitCodeReporterTest {
+
+    @Test
+    public void whenNoTestsRunExitCodeIs4() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.blockHookFail(null, null, null);
+        reporter.testHookFail(null, null, null, null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(4);
+    }
+
+    @Test
+    public void whenBlockHookFailReportedExitCodeIs1() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.testStart(null, null);
+        reporter.blockHookFail(null, null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenTestHookFailReportedExitCodeIs1() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.testStart(null, null);
+        reporter.testHookFail(null, null, null, null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenTestFailReportedExitCodeIs1() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.testStart(null, null);
+        reporter.testFail(null, null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenTestSkippedReportedExitCodeIs2() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.testStart(null, null);
+        reporter.testSkip(null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(2);
+    }
+
+    @Test
+    public void whenTestPendingReportedExitCodeIs3() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.testStart(null, null);
+        reporter.testPending(null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(3);
+    }
+
+    @Test
+    public void whenTestFailAndTestSkipReportedExitCodeIs1() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.testStart(null, null);
+        reporter.testFail(null, null, null);
+        reporter.testSkip(null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenTestFailAndTestPendingReportedExitCodeIs1() {
+        //Given
+        ExitCodeReporter reporter = new ExitCodeReporter();
+
+        //When
+        reporter.testStart(null, null);
+        reporter.testFail(null, null, null);
+        reporter.testPending(null, null);
+
+        //Then
+        assertThat(reporter.getExitCode()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Uses a `Reporter` to track the failed, skipped, pending results to determine the final status of the test run.