### PR TITLE
Updating the org.apache.maven.surefire version to 2.22.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ allprojects {
   apply plugin: 'jacoco'
 
   group = 'org.forgerock.cuppa'
-  version = '1.6.0'
+  version = '1.7.0'
 
   repositories {
     mavenLocal()

--- a/cuppa-surefire/build.gradle
+++ b/cuppa-surefire/build.gradle
@@ -2,6 +2,6 @@ description = 'Cuppa Maven Surefire Integration'
 
 dependencies {
     compile project(':cuppa')
-    provided group: 'org.apache.maven.surefire', name: 'surefire-api', version: '2.19.1', transitive: false
-    compile group: 'org.apache.maven.surefire', name: 'common-java5', version: '2.19.1', transitive: false
+    provided group: 'org.apache.maven.surefire', name: 'surefire-api', version: '2.22.2', transitive: false
+    compile group: 'org.apache.maven.surefire', name: 'common-java5', version: '2.22.2', transitive: false
 }


### PR DESCRIPTION
Updating the org.apache.maven.surefire 
surefire-api and common-java5 version to 2.22.2 for compatibility with AM's maven-surefire-plugin which has also been updated to 2.22.2 to support JUnit5 execution and reporting